### PR TITLE
Improve mBank CSV exports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,10 @@
     "vscode": {
       "extensions": [
         "biomejs.biome",
-        "EditorConfig.EditorConfig"
+        "EditorConfig.EditorConfig",
+        "shopify.ruby-lsp",
+        "shopify.ruby-extensions-pack",
+        "anthropic.claude-code"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ data/*
 
 # Cache data
 /db/schema_cache.yml
+
+# Devcontainer data
+/.devcontainer/devcontainer.env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Layout/IndentationStyle:
 
 Layout/IndentationConsistency:
   Enabled: true
+  EnforcedStyle: normal
 
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "inline_svg"
 gem "octokit"
 gem "pagy"
 gem "rails-settings-cached"
-gem "tzinfo-data", platforms: %i[windows jruby]
+gem "tzinfo-data", platforms: %i[mswin mswin64 mingw x64_mingw jruby]
 gem "csv"
 gem "redcarpet"
 gem "stripe"
@@ -84,7 +84,7 @@ gem "after_commit_everywhere", "~> 1.0"
 gem "ruby-openai"
 
 group :development, :test do
-  gem "debug", platforms: %i[mri windows]
+  gem "debug", platforms: %i[mri mswin mswin64 mingw x64_mingw]
   gem "brakeman", require: false
   gem "rubocop-rails-omakase", require: false
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -3,8 +3,8 @@ module ApplicationCable
     rescue_from StandardError, with: :report_error
 
     private
-      def report_error(e)
-        Sentry.capture_exception(e)
-      end
+    def report_error(e)
+      Sentry.capture_exception(e)
+    end
   end
 end

--- a/app/components/DS/alert.rb
+++ b/app/components/DS/alert.rb
@@ -5,48 +5,48 @@ class DS::Alert < DesignSystemComponent
   end
 
   private
-    attr_reader :message, :variant
+  attr_reader :message, :variant
 
-    def container_classes
-      base_classes = "flex items-start gap-3 p-4 rounded-lg border"
+  def container_classes
+    base_classes = "flex items-start gap-3 p-4 rounded-lg border"
 
-      variant_classes = case variant
-      when :info
-        "bg-blue-50 text-blue-700 border-blue-200 theme-dark:bg-blue-900/20 theme-dark:text-blue-400 theme-dark:border-blue-800"
-      when :success
-        "bg-green-50 text-green-700 border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-400 theme-dark:border-green-800"
-      when :warning
-        "bg-yellow-50 text-yellow-700 border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-400 theme-dark:border-yellow-800"
-      when :error, :destructive
-        "bg-red-50 text-red-700 border-red-200 theme-dark:bg-red-900/20 theme-dark:text-red-400 theme-dark:border-red-800"
-      end
-
-      "#{base_classes} #{variant_classes}"
+    variant_classes = case variant
+    when :info
+      "bg-blue-50 text-blue-700 border-blue-200 theme-dark:bg-blue-900/20 theme-dark:text-blue-400 theme-dark:border-blue-800"
+    when :success
+      "bg-green-50 text-green-700 border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-400 theme-dark:border-green-800"
+    when :warning
+      "bg-yellow-50 text-yellow-700 border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-400 theme-dark:border-yellow-800"
+    when :error, :destructive
+      "bg-red-50 text-red-700 border-red-200 theme-dark:bg-red-900/20 theme-dark:text-red-400 theme-dark:border-red-800"
     end
 
-    def icon_name
-      case variant
-      when :info
-        "info"
-      when :success
-        "check-circle"
-      when :warning
-        "alert-triangle"
-      when :error, :destructive
-        "x-circle"
-      end
-    end
+    "#{base_classes} #{variant_classes}"
+  end
 
-    def icon_color
-      case variant
-      when :success
-        "success"
-      when :warning
-        "warning"
-      when :error, :destructive
-        "destructive"
-      else
-        "blue-600"
-      end
+  def icon_name
+    case variant
+    when :info
+      "info"
+    when :success
+      "check-circle"
+    when :warning
+      "alert-triangle"
+    when :error, :destructive
+      "x-circle"
     end
+  end
+
+  def icon_color
+    case variant
+    when :success
+      "success"
+    when :warning
+      "warning"
+    when :error, :destructive
+      "destructive"
+    else
+      "blue-600"
+    end
+  end
 end

--- a/app/components/DS/button.rb
+++ b/app/components/DS/button.rb
@@ -19,23 +19,23 @@ class DS::Button < DS::Buttonish
   end
 
   private
-    def merged_opts
-      merged_opts = opts.dup || {}
-      extra_classes = merged_opts.delete(:class)
-      href = merged_opts.delete(:href)
-      data = merged_opts.delete(:data) || {}
+  def merged_opts
+    merged_opts = opts.dup || {}
+    extra_classes = merged_opts.delete(:class)
+    href = merged_opts.delete(:href)
+    data = merged_opts.delete(:data) || {}
 
-      if confirm.present?
-        data = data.merge(turbo_confirm: confirm.to_data_attribute)
-      end
-
-      if frame.present?
-        data = data.merge(turbo_frame: frame)
-      end
-
-      merged_opts.merge(
-        class: class_names(container_classes, extra_classes),
-        data: data
-      )
+    if confirm.present?
+      data = data.merge(turbo_confirm: confirm.to_data_attribute)
     end
+
+    if frame.present?
+      data = data.merge(turbo_frame: frame)
+    end
+
+    merged_opts.merge(
+      class: class_names(container_classes, extra_classes),
+      data: data
+    )
+  end
 end

--- a/app/components/DS/buttonish.rb
+++ b/app/components/DS/buttonish.rb
@@ -112,45 +112,45 @@ class DS::Buttonish < DesignSystemComponent
   end
 
   private
-    def variant_data
-      self.class::VARIANTS.dig(variant)
+  def variant_data
+    self.class::VARIANTS.dig(variant)
+  end
+
+  def size_data
+    self.class::SIZES.dig(size)
+  end
+
+  # Make sure that user can override common classes like `hidden`
+  def merged_base_classes
+    base_display_classes = "inline-flex items-center gap-1"
+    base_radius_classes = size_data.dig(:radius_classes)
+
+    extra_classes_list = (extra_classes || "").split
+
+    has_display_override = extra_classes_list.any? { |c| permitted_display_override_classes.include?(c) }
+    has_radius_override = extra_classes_list.any? { |c| permitted_radius_override_classes.include?(c) }
+
+    base_classes = []
+
+    unless has_display_override
+      base_classes << base_display_classes
     end
 
-    def size_data
-      self.class::SIZES.dig(size)
+    unless has_radius_override
+      base_classes << base_radius_classes
     end
 
-    # Make sure that user can override common classes like `hidden`
-    def merged_base_classes
-      base_display_classes = "inline-flex items-center gap-1"
-      base_radius_classes = size_data.dig(:radius_classes)
+    class_names(
+      base_classes,
+      extra_classes
+    )
+  end
 
-      extra_classes_list = (extra_classes || "").split
+  def permitted_radius_override_classes
+    ["rounded-full"]
+  end
 
-      has_display_override = extra_classes_list.any? { |c| permitted_display_override_classes.include?(c) }
-      has_radius_override = extra_classes_list.any? { |c| permitted_radius_override_classes.include?(c) }
-
-      base_classes = []
-
-      unless has_display_override
-        base_classes << base_display_classes
-      end
-
-      unless has_radius_override
-        base_classes << base_radius_classes
-      end
-
-      class_names(
-        base_classes,
-        extra_classes
-      )
-    end
-
-    def permitted_radius_override_classes
-      ["rounded-full"]
-    end
-
-    def permitted_display_override_classes
-      ["hidden", "flex"]
-    end
+  def permitted_display_override_classes
+    ["hidden", "flex"]
+  end
 end

--- a/app/components/DS/filled_icon.rb
+++ b/app/components/DS/filled_icon.rb
@@ -66,34 +66,34 @@ class DS::FilledIcon < DesignSystemComponent
   end
 
   private
-    def solid_bg_class
-      case variant
-      when :surface
-        "bg-surface-inset"
-      when :container
-        "bg-container-inset"
-      when :inverse
-        "bg-container"
-      end
+  def solid_bg_class
+    case variant
+    when :surface
+      "bg-surface-inset"
+    when :container
+      "bg-container-inset"
+    when :inverse
+      "bg-container"
     end
+  end
 
-    def size_classes
-      SIZES[size][:container_size]
-    end
+  def size_classes
+    SIZES[size][:container_size]
+  end
 
-    def radius_classes
-      rounded ? "rounded-full" : SIZES[size][:container_radius]
-    end
+  def radius_classes
+    rounded ? "rounded-full" : SIZES[size][:container_radius]
+  end
 
-    def custom_fg_color
-      hex_color || "var(--color-gray-500)"
-    end
+  def custom_fg_color
+    hex_color || "var(--color-gray-500)"
+  end
 
-    def transparent_bg_color
-      "color-mix(in oklab, #{custom_fg_color} 10%, transparent)"
-    end
+  def transparent_bg_color
+    "color-mix(in oklab, #{custom_fg_color} 10%, transparent)"
+  end
 
-    def transparent_border_color
-      "color-mix(in oklab, #{custom_fg_color} 10%, transparent)"
-    end
+  def transparent_border_color
+    "color-mix(in oklab, #{custom_fg_color} 10%, transparent)"
+  end
 end

--- a/app/components/DS/link.rb
+++ b/app/components/DS/link.rb
@@ -25,7 +25,7 @@ class DS::Link < DS::Buttonish
   end
 
   private
-    def container_size_classes
-      super unless variant == :default
-    end
+  def container_size_classes
+    super unless variant == :default
+  end
 end

--- a/app/components/DS/menu_item.rb
+++ b/app/components/DS/menu_item.rb
@@ -38,25 +38,25 @@ class DS::MenuItem < DesignSystemComponent
   end
 
   private
-    def container_classes
-      [
-        "flex items-center gap-2 p-2 rounded-md w-full",
-        destructive? ? "hover:bg-red-tint-5 theme-dark:hover:bg-red-tint-10" : "hover:bg-container-hover"
-      ].join(" ")
+  def container_classes
+    [
+      "flex items-center gap-2 p-2 rounded-md w-full",
+      destructive? ? "hover:bg-red-tint-5 theme-dark:hover:bg-red-tint-10" : "hover:bg-container-hover"
+    ].join(" ")
+  end
+
+  def merged_opts
+    merged_opts = opts.dup || {}
+    data = merged_opts.delete(:data) || {}
+
+    if confirm.present?
+      data = data.merge(turbo_confirm: confirm.to_data_attribute)
     end
 
-    def merged_opts
-      merged_opts = opts.dup || {}
-      data = merged_opts.delete(:data) || {}
-
-      if confirm.present?
-        data = data.merge(turbo_confirm: confirm.to_data_attribute)
-      end
-
-      if frame.present?
-        data = data.merge(turbo_frame: frame)
-      end
-
-      merged_opts.merge(data: data)
+    if frame.present?
+      data = data.merge(turbo_frame: frame)
     end
+
+    merged_opts.merge(data: data)
+  end
 end

--- a/app/components/DS/tabs.rb
+++ b/app/components/DS/tabs.rb
@@ -48,19 +48,19 @@ class DS::Tabs < DesignSystemComponent
   end
 
   private
-    def unstyled?
-      variant == :unstyled
-    end
+  def unstyled?
+    variant == :unstyled
+  end
 
-    def base_btn_classes
-      unless unstyled?
-        VARIANTS.dig(variant, :base_btn_classes)
-      end
+  def base_btn_classes
+    unless unstyled?
+      VARIANTS.dig(variant, :base_btn_classes)
     end
+  end
 
-    def nav_container_classes
-      unless unstyled?
-        VARIANTS.dig(variant, :nav_container_classes)
-      end
+  def nav_container_classes
+    unless unstyled?
+      VARIANTS.dig(variant, :nav_container_classes)
     end
+  end
 end

--- a/app/components/UI/account/activity_feed.rb
+++ b/app/components/UI/account/activity_feed.rb
@@ -29,7 +29,7 @@ class UI::Account::ActivityFeed < ApplicationComponent
   end
 
   private
-    def account
-      feed_data.account
-    end
+  def account
+    feed_data.account
+  end
 end

--- a/app/components/UI/account/balance_reconciliation.rb
+++ b/app/components/UI/account/balance_reconciliation.rb
@@ -27,129 +27,129 @@ class UI::Account::BalanceReconciliation < ApplicationComponent
 
   private
 
-    def default_items
-      items = [
-        { label: "Start balance", value: balance.start_balance_money, tooltip: "The account balance at the beginning of this day", style: :start },
-        { label: "Net cash flow", value: net_cash_flow, tooltip: "Net change in balance from all transactions during the day", style: :flow }
-      ]
+  def default_items
+    items = [
+      { label: "Start balance", value: balance.start_balance_money, tooltip: "The account balance at the beginning of this day", style: :start },
+      { label: "Net cash flow", value: net_cash_flow, tooltip: "Net change in balance from all transactions during the day", style: :flow }
+    ]
 
-      if has_adjustments?
-        items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all transactions", style: :subtotal }
-        items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
-      end
-
-      items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final account balance for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all transactions", style: :subtotal }
+      items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
     end
 
-    def credit_card_items
-      items = [
-        { label: "Start balance", value: balance.start_balance_money, tooltip: "The balance owed at the beginning of this day", style: :start },
-        { label: "Charges", value: balance.cash_outflows_money, tooltip: "New charges made during the day", style: :flow },
-        { label: "Payments", value: balance.cash_inflows_money * -1, tooltip: "Payments made to the card during the day", style: :flow }
-      ]
+    items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final account balance for the day", style: :final }
+    items
+  end
 
-      if has_adjustments?
-        items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all transactions", style: :subtotal }
-        items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
-      end
+  def credit_card_items
+    items = [
+      { label: "Start balance", value: balance.start_balance_money, tooltip: "The balance owed at the beginning of this day", style: :start },
+      { label: "Charges", value: balance.cash_outflows_money, tooltip: "New charges made during the day", style: :flow },
+      { label: "Payments", value: balance.cash_inflows_money * -1, tooltip: "Payments made to the card during the day", style: :flow }
+    ]
 
-      items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final balance owed for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all transactions", style: :subtotal }
+      items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
     end
 
-    def investment_items
-      items = [
-        { label: "Start balance", value: balance.start_balance_money, tooltip: "The total portfolio value at the beginning of this day", style: :start }
-      ]
+    items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final balance owed for the day", style: :final }
+    items
+  end
 
-      # Change in brokerage cash (includes deposits, withdrawals, and cash from trades)
-      items << { label: "Change in brokerage cash", value: net_cash_flow, tooltip: "Net change in cash from deposits, withdrawals, and trades", style: :flow }
+  def investment_items
+    items = [
+      { label: "Start balance", value: balance.start_balance_money, tooltip: "The total portfolio value at the beginning of this day", style: :start }
+    ]
 
-      # Change in holdings from trading activity
-      items << { label: "Change in holdings (buys/sells)", value: net_non_cash_flow, tooltip: "Impact on holdings from buying and selling securities", style: :flow }
+    # Change in brokerage cash (includes deposits, withdrawals, and cash from trades)
+    items << { label: "Change in brokerage cash", value: net_cash_flow, tooltip: "Net change in cash from deposits, withdrawals, and trades", style: :flow }
 
-      # Market price changes
-      items << { label: "Change in holdings (market price activity)", value: balance.net_market_flows_money, tooltip: "Change in holdings value from market price movements", style: :flow }
+    # Change in holdings from trading activity
+    items << { label: "Change in holdings (buys/sells)", value: net_non_cash_flow, tooltip: "Impact on holdings from buying and selling securities", style: :flow }
 
-      if has_adjustments?
-        items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all activity", style: :subtotal }
-        items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
-      end
+    # Market price changes
+    items << { label: "Change in holdings (market price activity)", value: balance.net_market_flows_money, tooltip: "Change in holdings value from market price movements", style: :flow }
 
-      items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final portfolio value for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all activity", style: :subtotal }
+      items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
     end
 
-    def loan_items
-      items = [
-        { label: "Start principal", value: balance.start_balance_money, tooltip: "The principal balance at the beginning of this day", style: :start },
-        { label: "Net principal change", value: net_non_cash_flow, tooltip: "Principal payments and new borrowing during the day", style: :flow }
-      ]
+    items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final portfolio value for the day", style: :final }
+    items
+  end
 
-      if has_adjustments?
-        items << { label: "End principal", value: end_balance_before_adjustments, tooltip: "The calculated principal after all transactions", style: :subtotal }
-        items << { label: "Adjustments", value: balance.non_cash_adjustments_money, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
-      end
+  def loan_items
+    items = [
+      { label: "Start principal", value: balance.start_balance_money, tooltip: "The principal balance at the beginning of this day", style: :start },
+      { label: "Net principal change", value: net_non_cash_flow, tooltip: "Principal payments and new borrowing during the day", style: :flow }
+    ]
 
-      items << { label: "Final principal", value: balance.end_balance_money, tooltip: "The final principal balance for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End principal", value: end_balance_before_adjustments, tooltip: "The calculated principal after all transactions", style: :subtotal }
+      items << { label: "Adjustments", value: balance.non_cash_adjustments_money, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
     end
 
-    def asset_items # Property/Vehicle
-      items = [
-        { label: "Start value", value: balance.start_balance_money, tooltip: "The asset value at the beginning of this day", style: :start },
-        { label: "Net value change", value: net_total_flow, tooltip: "All value changes including improvements and depreciation", style: :flow }
-      ]
+    items << { label: "Final principal", value: balance.end_balance_money, tooltip: "The final principal balance for the day", style: :final }
+    items
+  end
 
-      if has_adjustments?
-        items << { label: "End value", value: end_balance_before_adjustments, tooltip: "The calculated value after all changes", style: :subtotal }
-        items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual value adjustments or appraisals", style: :adjustment }
-      end
+  def asset_items # Property/Vehicle
+    items = [
+      { label: "Start value", value: balance.start_balance_money, tooltip: "The asset value at the beginning of this day", style: :start },
+      { label: "Net value change", value: net_total_flow, tooltip: "All value changes including improvements and depreciation", style: :flow }
+    ]
 
-      items << { label: "Final value", value: balance.end_balance_money, tooltip: "The final asset value for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End value", value: end_balance_before_adjustments, tooltip: "The calculated value after all changes", style: :subtotal }
+      items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual value adjustments or appraisals", style: :adjustment }
     end
 
-    def crypto_items
-      items = [
-        { label: "Start balance", value: balance.start_balance_money, tooltip: "The crypto holdings value at the beginning of this day", style: :start }
-      ]
+    items << { label: "Final value", value: balance.end_balance_money, tooltip: "The final asset value for the day", style: :final }
+    items
+  end
 
-      items << { label: "Buys", value: balance.cash_outflows_money * -1, tooltip: "Crypto purchases during the day", style: :flow } if balance.cash_outflows != 0
-      items << { label: "Sells", value: balance.cash_inflows_money, tooltip: "Crypto sales during the day", style: :flow } if balance.cash_inflows != 0
-      items << { label: "Market changes", value: balance.net_market_flows_money, tooltip: "Value changes from market price movements", style: :flow } if balance.net_market_flows != 0
+  def crypto_items
+    items = [
+      { label: "Start balance", value: balance.start_balance_money, tooltip: "The crypto holdings value at the beginning of this day", style: :start }
+    ]
 
-      if has_adjustments?
-        items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all activity", style: :subtotal }
-        items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
-      end
+    items << { label: "Buys", value: balance.cash_outflows_money * -1, tooltip: "Crypto purchases during the day", style: :flow } if balance.cash_outflows != 0
+    items << { label: "Sells", value: balance.cash_inflows_money, tooltip: "Crypto sales during the day", style: :flow } if balance.cash_inflows != 0
+    items << { label: "Market changes", value: balance.net_market_flows_money, tooltip: "Value changes from market price movements", style: :flow } if balance.net_market_flows != 0
 
-      items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final crypto holdings value for the day", style: :final }
-      items
+    if has_adjustments?
+      items << { label: "End balance", value: end_balance_before_adjustments, tooltip: "The calculated balance after all activity", style: :subtotal }
+      items << { label: "Adjustments", value: total_adjustments, tooltip: "Manual reconciliations or other adjustments", style: :adjustment }
     end
 
-    def net_cash_flow
-      balance.cash_inflows_money - balance.cash_outflows_money
-    end
+    items << { label: "Final balance", value: balance.end_balance_money, tooltip: "The final crypto holdings value for the day", style: :final }
+    items
+  end
 
-    def net_non_cash_flow
-      balance.non_cash_inflows_money - balance.non_cash_outflows_money
-    end
+  def net_cash_flow
+    balance.cash_inflows_money - balance.cash_outflows_money
+  end
 
-    def net_total_flow
-      net_cash_flow + net_non_cash_flow + balance.net_market_flows_money
-    end
+  def net_non_cash_flow
+    balance.non_cash_inflows_money - balance.non_cash_outflows_money
+  end
 
-    def total_adjustments
-      balance.cash_adjustments_money + balance.non_cash_adjustments_money
-    end
+  def net_total_flow
+    net_cash_flow + net_non_cash_flow + balance.net_market_flows_money
+  end
 
-    def has_adjustments?
-      balance.cash_adjustments != 0 || balance.non_cash_adjustments != 0
-    end
+  def total_adjustments
+    balance.cash_adjustments_money + balance.non_cash_adjustments_money
+  end
 
-    def end_balance_before_adjustments
-      balance.end_balance_money - total_adjustments
-    end
+  def has_adjustments?
+    balance.cash_adjustments != 0 || balance.non_cash_adjustments != 0
+  end
+
+  def end_balance_before_adjustments
+    balance.end_balance_money - total_adjustments
+  end
 end

--- a/app/controllers/accountable_sparklines_controller.rb
+++ b/app/controllers/accountable_sparklines_controller.rb
@@ -23,19 +23,19 @@ class AccountableSparklinesController < ApplicationController
   end
 
   private
-    def family
-      Current.family
-    end
+  def family
+    Current.family
+  end
 
-    def accountable
-      Accountable.from_type(params[:accountable_type]&.classify)
-    end
+  def accountable
+    Accountable.from_type(params[:accountable_type]&.classify)
+  end
 
-    def account_ids
-      family.accounts.visible.where(accountable_type: accountable.name).pluck(:id)
-    end
+  def account_ids
+    family.accounts.visible.where(accountable_type: accountable.name).pluck(:id)
+  end
 
-    def cache_key
-      family.build_cache_key("#{@accountable.name}_sparkline", invalidate_on_data_updates: true)
-    end
+  def cache_key
+    family.build_cache_key("#{@accountable.name}_sparkline", invalidate_on_data_updates: true)
+  end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -63,11 +63,11 @@ class AccountsController < ApplicationController
   end
 
   private
-    def family
-      Current.family
-    end
+  def family
+    Current.family
+  end
 
-    def set_account
-      @account = family.accounts.find(params[:id])
-    end
+  def set_account
+    @account = family.accounts.find(params[:id])
+  end
 end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -34,26 +34,26 @@ end
 
     private
 
-      def ensure_read_scope
-        authorize_scope!(:read)
-      end
+  def ensure_read_scope
+    authorize_scope!(:read)
+  end
 
 
 
-      def safe_page_param
-        page = params[:page].to_i
-        page > 0 ? page : 1
-      end
+  def safe_page_param
+    page = params[:page].to_i
+    page > 0 ? page : 1
+  end
 
-      def safe_per_page_param
-        per_page = params[:per_page].to_i
+  def safe_per_page_param
+    per_page = params[:per_page].to_i
 
-        # Default to 25, max 100
-        case per_page
-        when 1..100
-          per_page
-        else
-          25
-        end
-      end
+    # Default to 25, max 100
+    case per_page
+    when 1..100
+      per_page
+    else
+      25
+    end
+  end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -33,247 +33,247 @@ class Api::V1::BaseController < ApplicationController
 
   private
 
-    # Force JSON format for all API requests
-    def force_json_format
-      request.format = :json
+  # Force JSON format for all API requests
+  def force_json_format
+    request.format = :json
+  end
+
+  # Authenticate using either OAuth or API key
+  def authenticate_request!
+    return if authenticate_oauth
+    return if authenticate_api_key
+    render_unauthorized unless performed?
+  end
+
+  # Try OAuth authentication first
+  def authenticate_oauth
+    return false unless request.headers["Authorization"].present?
+
+    # Manually verify the token (bypassing doorkeeper_authorize! which had scope issues)
+    token_string = request.authorization&.split(" ")&.last
+    access_token = Doorkeeper::AccessToken.by_token(token_string)
+
+    # Check token validity and scope (read_write includes read access)
+    has_sufficient_scope = access_token&.scopes&.include?("read") || access_token&.scopes&.include?("read_write")
+
+    unless access_token && !access_token.expired? && has_sufficient_scope
+      render_json({ error: "unauthorized", message: "Access token is invalid, expired, or missing required scope" }, status: :unauthorized)
+      return false
     end
 
-    # Authenticate using either OAuth or API key
-    def authenticate_request!
-      return if authenticate_oauth
-      return if authenticate_api_key
-      render_unauthorized unless performed?
-    end
+    # Set the doorkeeper_token for compatibility
+    @_doorkeeper_token = access_token
 
-    # Try OAuth authentication first
-    def authenticate_oauth
-      return false unless request.headers["Authorization"].present?
+    if doorkeeper_token&.resource_owner_id
+      @current_user = User.find_by(id: doorkeeper_token.resource_owner_id)
 
-      # Manually verify the token (bypassing doorkeeper_authorize! which had scope issues)
-      token_string = request.authorization&.split(" ")&.last
-      access_token = Doorkeeper::AccessToken.by_token(token_string)
-
-      # Check token validity and scope (read_write includes read access)
-      has_sufficient_scope = access_token&.scopes&.include?("read") || access_token&.scopes&.include?("read_write")
-
-      unless access_token && !access_token.expired? && has_sufficient_scope
-        render_json({ error: "unauthorized", message: "Access token is invalid, expired, or missing required scope" }, status: :unauthorized)
+      # If user doesn't exist, the token is invalid (user was deleted)
+      unless @current_user
+        Rails.logger.warn "API OAuth Token Invalid: Access token resource_owner_id #{doorkeeper_token.resource_owner_id} does not exist"
+        render_json({ error: "unauthorized", message: "Access token is invalid - user not found" }, status: :unauthorized)
         return false
       end
+    else
+      Rails.logger.warn "API OAuth Token Invalid: Access token missing resource_owner_id"
+      render_json({ error: "unauthorized", message: "Access token is invalid - missing resource owner" }, status: :unauthorized)
+      return false
+    end
 
-      # Set the doorkeeper_token for compatibility
-      @_doorkeeper_token = access_token
+    @authentication_method = :oauth
+    setup_current_context_for_api
+    true
+  rescue Doorkeeper::Errors::DoorkeeperError => e
+    Rails.logger.warn "API OAuth Error: #{e.message}"
+    false
+  end
 
-      if doorkeeper_token&.resource_owner_id
-        @current_user = User.find_by(id: doorkeeper_token.resource_owner_id)
+  # Try API key authentication
+  def authenticate_api_key
+    api_key_value = request.headers["X-Api-Key"]
+    return false unless api_key_value
 
-        # If user doesn't exist, the token is invalid (user was deleted)
-        unless @current_user
-          Rails.logger.warn "API OAuth Token Invalid: Access token resource_owner_id #{doorkeeper_token.resource_owner_id} does not exist"
-          render_json({ error: "unauthorized", message: "Access token is invalid - user not found" }, status: :unauthorized)
-          return false
-        end
+    @api_key = ApiKey.find_by_value(api_key_value)
+    return false unless @api_key && @api_key.active?
+
+    @current_user = @api_key.user
+    @api_key.update_last_used!
+    @authentication_method = :api_key
+    @rate_limiter = ApiRateLimiter.limit(@api_key)
+    setup_current_context_for_api
+    true
+  end
+
+  # Check rate limits for API key authentication
+  def check_api_key_rate_limit
+    return unless @authentication_method == :api_key && @rate_limiter
+
+    if @rate_limiter.rate_limit_exceeded?
+      usage_info = @rate_limiter.usage_info
+      render_rate_limit_exceeded(usage_info)
+      return false
+    end
+
+    # Increment request count for successful API key requests
+    @rate_limiter.increment_request_count!
+
+    # Add rate limit headers to response
+    add_rate_limit_headers(@rate_limiter.usage_info)
+  end
+
+  # Render rate limit exceeded response
+  def render_rate_limit_exceeded(usage_info)
+    response.headers["X-RateLimit-Limit"] = usage_info[:rate_limit].to_s
+    response.headers["X-RateLimit-Remaining"] = "0"
+    response.headers["X-RateLimit-Reset"] = usage_info[:reset_time].to_s
+    response.headers["Retry-After"] = usage_info[:reset_time].to_s
+
+    Rails.logger.warn "API Rate Limit Exceeded: API Key #{@api_key.name} (User: #{@current_user.email}) - #{usage_info[:current_count]}/#{usage_info[:rate_limit]} requests"
+
+    render_json({
+      error: "rate_limit_exceeded",
+      message: "Rate limit exceeded. Try again in #{usage_info[:reset_time]} seconds.",
+      details: {
+        limit: usage_info[:rate_limit],
+        current: usage_info[:current_count],
+        reset_in_seconds: usage_info[:reset_time]
+      }
+    }, status: :too_many_requests)
+  end
+
+  # Add rate limit headers to successful responses
+  def add_rate_limit_headers(usage_info)
+    response.headers["X-RateLimit-Limit"] = usage_info[:rate_limit].to_s
+    response.headers["X-RateLimit-Remaining"] = usage_info[:remaining].to_s
+    response.headers["X-RateLimit-Reset"] = usage_info[:reset_time].to_s
+  end
+
+  # Render unauthorized response
+  def render_unauthorized
+    render_json({ error: "unauthorized", message: "Access token or API key is invalid, expired, or missing" }, status: :unauthorized)
+  end
+
+  # Returns the user that owns the access token or API key
+  def current_resource_owner
+    @current_user
+  end
+
+  # Get current scopes from either authentication method
+  def current_scopes
+    case @authentication_method
+    when :oauth
+      doorkeeper_token&.scopes&.to_a || []
+    when :api_key
+      @api_key&.scopes || []
+    else
+      []
+    end
+  end
+
+  # Check if the current authentication has the required scope
+  # Implements hierarchical scope checking where read_write includes read access
+  def authorize_scope!(required_scope)
+    scopes = current_scopes
+
+    case required_scope.to_s
+    when "read"
+      # Read access requires either "read" or "read_write" scope
+      has_access = scopes.include?("read") || scopes.include?("read_write")
+    when "write"
+      # Write access requires "read_write" scope
+      has_access = scopes.include?("read_write")
+    else
+      # For any other scope, check exact match (backward compatibility)
+      has_access = scopes.include?(required_scope.to_s)
+    end
+
+    unless has_access
+      Rails.logger.warn "API Insufficient Scope: User #{current_resource_owner&.email} attempted to access #{required_scope} but only has #{scopes}"
+      render_json({ error: "insufficient_scope", message: "This action requires the '#{required_scope}' scope" }, status: :forbidden)
+      return false
+    end
+    true
+  end
+
+  # Consistent JSON response method
+  def render_json(data, status: :ok)
+    render json: data, status: status
+  end
+
+  # Error handlers
+  def handle_not_found(exception)
+    Rails.logger.warn "API Record Not Found: #{exception.message}"
+    render_json({ error: "record_not_found", message: "The requested resource was not found" }, status: :not_found)
+  end
+
+  def handle_unauthorized(exception)
+    Rails.logger.warn "API Unauthorized: #{exception.message}"
+    render_json({ error: "unauthorized", message: "Access token is invalid or expired" }, status: :unauthorized)
+  end
+
+  def handle_bad_request(exception)
+    Rails.logger.warn "API Bad Request: #{exception.message}"
+    render_json({ error: "bad_request", message: "Required parameters are missing or invalid" }, status: :bad_request)
+  end
+
+  # Log API access for monitoring and debugging
+  def log_api_access
+    return unless current_resource_owner
+
+    auth_info = case @authentication_method
+    when :oauth
+      "OAuth Token"
+    when :api_key
+      "API Key: #{@api_key.name}"
+    else
+      "Unknown"
+    end
+
+    Rails.logger.info "API Request: #{request.method} #{request.path} - User: #{current_resource_owner.email} (Family: #{current_resource_owner.family_id}) - Auth: #{auth_info}"
+  end
+
+  # Family-based access control helper (to be used by subcontrollers)
+  def ensure_current_family_access(resource)
+    return unless resource.respond_to?(:family_id)
+
+    unless resource.family_id == current_resource_owner.family_id
+      Rails.logger.warn "API Forbidden: User #{current_resource_owner.email} attempted to access resource from family #{resource.family_id}"
+      render_json({ error: "forbidden", message: "Access denied to this resource" }, status: :forbidden)
+      return false
+    end
+
+    true
+  end
+
+  # Manual doorkeeper_token accessor for compatibility with manual token verification
+  def doorkeeper_token
+    @_doorkeeper_token
+  end
+
+  # Set up Current context for API requests since we don't use session-based auth
+  def setup_current_context_for_api
+    # For API requests, we need to create a minimal session-like object
+    # or find/create an actual session for this user to make Current.user work
+    if @current_user
+      # Try to find an existing session for this user, or create a temporary one
+      session = @current_user.sessions.first
+      if session
+        Current.session = session
       else
-        Rails.logger.warn "API OAuth Token Invalid: Access token missing resource_owner_id"
-        render_json({ error: "unauthorized", message: "Access token is invalid - missing resource owner" }, status: :unauthorized)
-        return false
-      end
-
-      @authentication_method = :oauth
-      setup_current_context_for_api
-      true
-    rescue Doorkeeper::Errors::DoorkeeperError => e
-      Rails.logger.warn "API OAuth Error: #{e.message}"
-      false
-    end
-
-    # Try API key authentication
-    def authenticate_api_key
-      api_key_value = request.headers["X-Api-Key"]
-      return false unless api_key_value
-
-      @api_key = ApiKey.find_by_value(api_key_value)
-      return false unless @api_key && @api_key.active?
-
-      @current_user = @api_key.user
-      @api_key.update_last_used!
-      @authentication_method = :api_key
-      @rate_limiter = ApiRateLimiter.limit(@api_key)
-      setup_current_context_for_api
-      true
-    end
-
-    # Check rate limits for API key authentication
-    def check_api_key_rate_limit
-      return unless @authentication_method == :api_key && @rate_limiter
-
-      if @rate_limiter.rate_limit_exceeded?
-        usage_info = @rate_limiter.usage_info
-        render_rate_limit_exceeded(usage_info)
-        return false
-      end
-
-      # Increment request count for successful API key requests
-      @rate_limiter.increment_request_count!
-
-      # Add rate limit headers to response
-      add_rate_limit_headers(@rate_limiter.usage_info)
-    end
-
-    # Render rate limit exceeded response
-    def render_rate_limit_exceeded(usage_info)
-      response.headers["X-RateLimit-Limit"] = usage_info[:rate_limit].to_s
-      response.headers["X-RateLimit-Remaining"] = "0"
-      response.headers["X-RateLimit-Reset"] = usage_info[:reset_time].to_s
-      response.headers["Retry-After"] = usage_info[:reset_time].to_s
-
-      Rails.logger.warn "API Rate Limit Exceeded: API Key #{@api_key.name} (User: #{@current_user.email}) - #{usage_info[:current_count]}/#{usage_info[:rate_limit]} requests"
-
-      render_json({
-        error: "rate_limit_exceeded",
-        message: "Rate limit exceeded. Try again in #{usage_info[:reset_time]} seconds.",
-        details: {
-          limit: usage_info[:rate_limit],
-          current: usage_info[:current_count],
-          reset_in_seconds: usage_info[:reset_time]
-        }
-      }, status: :too_many_requests)
-    end
-
-    # Add rate limit headers to successful responses
-    def add_rate_limit_headers(usage_info)
-      response.headers["X-RateLimit-Limit"] = usage_info[:rate_limit].to_s
-      response.headers["X-RateLimit-Remaining"] = usage_info[:remaining].to_s
-      response.headers["X-RateLimit-Reset"] = usage_info[:reset_time].to_s
-    end
-
-    # Render unauthorized response
-    def render_unauthorized
-      render_json({ error: "unauthorized", message: "Access token or API key is invalid, expired, or missing" }, status: :unauthorized)
-    end
-
-    # Returns the user that owns the access token or API key
-    def current_resource_owner
-      @current_user
-    end
-
-    # Get current scopes from either authentication method
-    def current_scopes
-      case @authentication_method
-      when :oauth
-        doorkeeper_token&.scopes&.to_a || []
-      when :api_key
-        @api_key&.scopes || []
-      else
-        []
+        # Create a temporary session for this API request
+        # This won't be persisted but will allow Current.user to work
+        session = @current_user.sessions.build(
+          user_agent: request.user_agent,
+          ip_address: request.ip
+        )
+        Current.session = session
       end
     end
+  end
 
-    # Check if the current authentication has the required scope
-    # Implements hierarchical scope checking where read_write includes read access
-    def authorize_scope!(required_scope)
-      scopes = current_scopes
-
-      case required_scope.to_s
-      when "read"
-        # Read access requires either "read" or "read_write" scope
-        has_access = scopes.include?("read") || scopes.include?("read_write")
-      when "write"
-        # Write access requires "read_write" scope
-        has_access = scopes.include?("read_write")
-      else
-        # For any other scope, check exact match (backward compatibility)
-        has_access = scopes.include?(required_scope.to_s)
-      end
-
-      unless has_access
-        Rails.logger.warn "API Insufficient Scope: User #{current_resource_owner&.email} attempted to access #{required_scope} but only has #{scopes}"
-        render_json({ error: "insufficient_scope", message: "This action requires the '#{required_scope}' scope" }, status: :forbidden)
-        return false
-      end
-      true
+  # Check if AI features are enabled for the current user
+  def require_ai_enabled
+    unless current_resource_owner&.ai_enabled?
+      render_json({ error: "feature_disabled", message: "AI features are not enabled for this user" }, status: :forbidden)
     end
-
-    # Consistent JSON response method
-    def render_json(data, status: :ok)
-      render json: data, status: status
-    end
-
-    # Error handlers
-    def handle_not_found(exception)
-      Rails.logger.warn "API Record Not Found: #{exception.message}"
-      render_json({ error: "record_not_found", message: "The requested resource was not found" }, status: :not_found)
-    end
-
-    def handle_unauthorized(exception)
-      Rails.logger.warn "API Unauthorized: #{exception.message}"
-      render_json({ error: "unauthorized", message: "Access token is invalid or expired" }, status: :unauthorized)
-    end
-
-    def handle_bad_request(exception)
-      Rails.logger.warn "API Bad Request: #{exception.message}"
-      render_json({ error: "bad_request", message: "Required parameters are missing or invalid" }, status: :bad_request)
-    end
-
-    # Log API access for monitoring and debugging
-    def log_api_access
-      return unless current_resource_owner
-
-      auth_info = case @authentication_method
-      when :oauth
-        "OAuth Token"
-      when :api_key
-        "API Key: #{@api_key.name}"
-      else
-        "Unknown"
-      end
-
-      Rails.logger.info "API Request: #{request.method} #{request.path} - User: #{current_resource_owner.email} (Family: #{current_resource_owner.family_id}) - Auth: #{auth_info}"
-    end
-
-    # Family-based access control helper (to be used by subcontrollers)
-    def ensure_current_family_access(resource)
-      return unless resource.respond_to?(:family_id)
-
-      unless resource.family_id == current_resource_owner.family_id
-        Rails.logger.warn "API Forbidden: User #{current_resource_owner.email} attempted to access resource from family #{resource.family_id}"
-        render_json({ error: "forbidden", message: "Access denied to this resource" }, status: :forbidden)
-        return false
-      end
-
-      true
-    end
-
-    # Manual doorkeeper_token accessor for compatibility with manual token verification
-    def doorkeeper_token
-      @_doorkeeper_token
-    end
-
-    # Set up Current context for API requests since we don't use session-based auth
-    def setup_current_context_for_api
-      # For API requests, we need to create a minimal session-like object
-      # or find/create an actual session for this user to make Current.user work
-      if @current_user
-        # Try to find an existing session for this user, or create a temporary one
-        session = @current_user.sessions.first
-        if session
-          Current.session = session
-        else
-          # Create a temporary session for this API request
-          # This won't be persisted but will allow Current.user to work
-          session = @current_user.sessions.build(
-            user_agent: request.user_agent,
-            ip_address: request.ip
-          )
-          Current.session = session
-        end
-      end
-    end
-
-    # Check if AI features are enabled for the current user
-    def require_ai_enabled
-      unless current_resource_owner&.ai_enabled?
-        render_json({ error: "feature_disabled", message: "AI features are not enabled for this user" }, status: :forbidden)
-      end
-    end
+  end
 end

--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -60,25 +60,25 @@ class Api::V1::ChatsController < Api::V1::BaseController
 
   private
 
-    def ensure_read_scope
-      authorize_scope!(:read)
-    end
+  def ensure_read_scope
+    authorize_scope!(:read)
+  end
 
-    def ensure_write_scope
-      authorize_scope!(:write)
-    end
+  def ensure_write_scope
+    authorize_scope!(:write)
+  end
 
-    def set_chat
-      @chat = Current.user.chats.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "Chat not found" }, status: :not_found
-    end
+  def set_chat
+    @chat = Current.user.chats.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Chat not found" }, status: :not_found
+  end
 
-    def chat_params
-      params.permit(:title, :message, :model)
-    end
+  def chat_params
+    params.permit(:title, :message, :model)
+  end
 
-    def update_chat_params
-      params.permit(:title)
-    end
+  def update_chat_params
+    params.permit(:title)
+  end
 end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -39,17 +39,17 @@ class Api::V1::MessagesController < Api::V1::BaseController
 
   private
 
-    def ensure_write_scope
-      authorize_scope!(:write)
-    end
+  def ensure_write_scope
+    authorize_scope!(:write)
+  end
 
-    def set_chat
-      @chat = Current.user.chats.find(params[:chat_id])
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "Chat not found" }, status: :not_found
-    end
+  def set_chat
+    @chat = Current.user.chats.find(params[:chat_id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Chat not found" }, status: :not_found
+  end
 
-    def message_params
-      params.permit(:content, :model)
-    end
+  def message_params
+    params.permit(:content, :model)
+  end
 end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -150,178 +150,178 @@ end
 
   private
 
-    def set_transaction
-      family = current_resource_owner.family
-      @transaction = family.transactions.find(params[:id])
-      @entry = @transaction.entry
-    rescue ActiveRecord::RecordNotFound
-      render json: {
-        error: "not_found",
-        message: "Transaction not found"
-      }, status: :not_found
+  def set_transaction
+    family = current_resource_owner.family
+    @transaction = family.transactions.find(params[:id])
+    @entry = @transaction.entry
+  rescue ActiveRecord::RecordNotFound
+    render json: {
+      error: "not_found",
+      message: "Transaction not found"
+    }, status: :not_found
+  end
+
+  def ensure_read_scope
+    authorize_scope!(:read)
+  end
+
+  def ensure_write_scope
+    authorize_scope!(:write)
+  end
+
+  def apply_filters(query)
+    # Account filtering
+    if params[:account_id].present?
+      query = query.joins(:entry).where(entries: { account_id: params[:account_id] })
     end
 
-    def ensure_read_scope
-      authorize_scope!(:read)
+    if params[:account_ids].present?
+      account_ids = Array(params[:account_ids])
+      query = query.joins(:entry).where(entries: { account_id: account_ids })
     end
 
-    def ensure_write_scope
-      authorize_scope!(:write)
+    # Category filtering
+    if params[:category_id].present?
+      query = query.where(category_id: params[:category_id])
     end
 
-    def apply_filters(query)
-      # Account filtering
-      if params[:account_id].present?
-        query = query.joins(:entry).where(entries: { account_id: params[:account_id] })
-      end
-
-      if params[:account_ids].present?
-        account_ids = Array(params[:account_ids])
-        query = query.joins(:entry).where(entries: { account_id: account_ids })
-      end
-
-      # Category filtering
-      if params[:category_id].present?
-        query = query.where(category_id: params[:category_id])
-      end
-
-      if params[:category_ids].present?
-        category_ids = Array(params[:category_ids])
-        query = query.where(category_id: category_ids)
-      end
-
-      # Merchant filtering
-      if params[:merchant_id].present?
-        query = query.where(merchant_id: params[:merchant_id])
-      end
-
-      if params[:merchant_ids].present?
-        merchant_ids = Array(params[:merchant_ids])
-        query = query.where(merchant_id: merchant_ids)
-      end
-
-      # Date range filtering
-      if params[:start_date].present?
-        query = query.joins(:entry).where("entries.date >= ?", Date.parse(params[:start_date]))
-      end
-
-      if params[:end_date].present?
-        query = query.joins(:entry).where("entries.date <= ?", Date.parse(params[:end_date]))
-      end
-
-      # Amount filtering
-      if params[:min_amount].present?
-        min_amount = params[:min_amount].to_f
-        query = query.joins(:entry).where("entries.amount >= ?", min_amount)
-      end
-
-      if params[:max_amount].present?
-        max_amount = params[:max_amount].to_f
-        query = query.joins(:entry).where("entries.amount <= ?", max_amount)
-      end
-
-      # Tag filtering
-      if params[:tag_ids].present?
-        tag_ids = Array(params[:tag_ids])
-        query = query.joins(:tags).where(tags: { id: tag_ids })
-      end
-
-      # Transaction type filtering (income/expense)
-      if params[:type].present?
-        case params[:type].downcase
-        when "income"
-          query = query.joins(:entry).where("entries.amount < 0")
-        when "expense"
-          query = query.joins(:entry).where("entries.amount > 0")
-        end
-      end
-
-      query
+    if params[:category_ids].present?
+      category_ids = Array(params[:category_ids])
+      query = query.where(category_id: category_ids)
     end
 
-    def apply_search(query)
-      search_term = "%#{params[:search]}%"
+    # Merchant filtering
+    if params[:merchant_id].present?
+      query = query.where(merchant_id: params[:merchant_id])
+    end
 
-      query.joins(:entry)
-           .left_joins(:merchant)
-           .where(
-             "entries.name ILIKE ? OR entries.notes ILIKE ? OR merchants.name ILIKE ?",
-             search_term, search_term, search_term
-           )
+    if params[:merchant_ids].present?
+      merchant_ids = Array(params[:merchant_ids])
+      query = query.where(merchant_id: merchant_ids)
+    end
+
+    # Date range filtering
+    if params[:start_date].present?
+      query = query.joins(:entry).where("entries.date >= ?", Date.parse(params[:start_date]))
+    end
+
+    if params[:end_date].present?
+      query = query.joins(:entry).where("entries.date <= ?", Date.parse(params[:end_date]))
+    end
+
+    # Amount filtering
+    if params[:min_amount].present?
+      min_amount = params[:min_amount].to_f
+      query = query.joins(:entry).where("entries.amount >= ?", min_amount)
+    end
+
+    if params[:max_amount].present?
+      max_amount = params[:max_amount].to_f
+      query = query.joins(:entry).where("entries.amount <= ?", max_amount)
+    end
+
+    # Tag filtering
+    if params[:tag_ids].present?
+      tag_ids = Array(params[:tag_ids])
+      query = query.joins(:tags).where(tags: { id: tag_ids })
+    end
+
+    # Transaction type filtering (income/expense)
+    if params[:type].present?
+      case params[:type].downcase
+      when "income"
+        query = query.joins(:entry).where("entries.amount < 0")
+      when "expense"
+        query = query.joins(:entry).where("entries.amount > 0")
+      end
+    end
+
+    query
+  end
+
+  def apply_search(query)
+    search_term = "%#{params[:search]}%"
+
+    query.joins(:entry)
+         .left_joins(:merchant)
+         .where(
+           "entries.name ILIKE ? OR entries.notes ILIKE ? OR merchants.name ILIKE ?",
+           search_term, search_term, search_term
+         )
 end
 
-    def transaction_params
-      params.require(:transaction).permit(
-        :account_id, :date, :amount, :name, :description, :notes, :currency,
-        :category_id, :merchant_id, :nature, tag_ids: []
-      )
-    end
+  def transaction_params
+    params.require(:transaction).permit(
+      :account_id, :date, :amount, :name, :description, :notes, :currency,
+      :category_id, :merchant_id, :nature, tag_ids: []
+    )
+  end
 
-    def entry_params_for_create
-      entry_params = {
-        name: transaction_params[:name] || transaction_params[:description],
-        date: transaction_params[:date],
-        amount: calculate_signed_amount,
-        currency: transaction_params[:currency] || current_resource_owner.family.currency,
-        notes: transaction_params[:notes],
-        entryable_type: "Transaction",
-        entryable_attributes: {
-          category_id: transaction_params[:category_id],
-          merchant_id: transaction_params[:merchant_id],
-          tag_ids: transaction_params[:tag_ids] || []
-        }
+  def entry_params_for_create
+    entry_params = {
+      name: transaction_params[:name] || transaction_params[:description],
+      date: transaction_params[:date],
+      amount: calculate_signed_amount,
+      currency: transaction_params[:currency] || current_resource_owner.family.currency,
+      notes: transaction_params[:notes],
+      entryable_type: "Transaction",
+      entryable_attributes: {
+        category_id: transaction_params[:category_id],
+        merchant_id: transaction_params[:merchant_id],
+        tag_ids: transaction_params[:tag_ids] || []
       }
+    }
 
-      entry_params.compact
+    entry_params.compact
+  end
+
+  def entry_params_for_update
+    entry_params = {
+      name: transaction_params[:name] || transaction_params[:description],
+      date: transaction_params[:date],
+      notes: transaction_params[:notes],
+      entryable_attributes: {
+        id: @entry.entryable_id,
+        category_id: transaction_params[:category_id],
+        merchant_id: transaction_params[:merchant_id],
+        tag_ids: transaction_params[:tag_ids]
+      }.compact_blank
+    }
+
+    # Only update amount if provided
+    if transaction_params[:amount].present?
+      entry_params[:amount] = calculate_signed_amount
     end
 
-    def entry_params_for_update
-      entry_params = {
-        name: transaction_params[:name] || transaction_params[:description],
-        date: transaction_params[:date],
-        notes: transaction_params[:notes],
-        entryable_attributes: {
-          id: @entry.entryable_id,
-          category_id: transaction_params[:category_id],
-          merchant_id: transaction_params[:merchant_id],
-          tag_ids: transaction_params[:tag_ids]
-        }.compact_blank
-      }
+    entry_params.compact
+  end
 
-      # Only update amount if provided
-      if transaction_params[:amount].present?
-        entry_params[:amount] = calculate_signed_amount
-      end
+  def calculate_signed_amount
+    amount = transaction_params[:amount].to_f
+    nature = transaction_params[:nature]
 
-      entry_params.compact
+    case nature&.downcase
+    when "income", "inflow"
+      -amount.abs  # Income is negative
+    when "expense", "outflow"
+      amount.abs   # Expense is positive
+    else
+      amount       # Use as provided
     end
+  end
 
-    def calculate_signed_amount
-      amount = transaction_params[:amount].to_f
-      nature = transaction_params[:nature]
+  def safe_page_param
+    page = params[:page].to_i
+    page > 0 ? page : 1
+  end
 
-      case nature&.downcase
-      when "income", "inflow"
-        -amount.abs  # Income is negative
-      when "expense", "outflow"
-        amount.abs   # Expense is positive
-      else
-        amount       # Use as provided
-      end
+  def safe_per_page_param
+    per_page = params[:per_page].to_i
+    case per_page
+    when 1..100
+      per_page
+    else
+      25  # Default
     end
-
-    def safe_page_param
-      page = params[:page].to_i
-      page > 0 ? page : 1
-    end
-
-    def safe_per_page_param
-      per_page = params[:per_page].to_i
-      case per_page
-      when 1..100
-        per_page
-      else
-        25  # Default
-      end
-    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,29 +10,29 @@ class ApplicationController < ActionController::Base
   before_action :set_active_storage_url_options
 
   private
-    def detect_os
-      user_agent = request.user_agent
-      @os = case user_agent
-      when /Windows/i then "windows"
-      when /Macintosh/i then "mac"
-      when /Linux/i then "linux"
-      when /Android/i then "android"
-      when /iPhone|iPad/i then "ios"
-      else ""
-      end
+  def detect_os
+    user_agent = request.user_agent
+    @os = case user_agent
+    when /Windows/i then "windows"
+    when /Macintosh/i then "mac"
+    when /Linux/i then "linux"
+    when /Android/i then "android"
+    when /iPhone|iPad/i then "ios"
+    else ""
     end
+  end
 
-    # By default, we show the user the last chat they interacted with
-    def set_default_chat
-      @last_viewed_chat = Current.user&.last_viewed_chat
-      @chat = @last_viewed_chat
-    end
+  # By default, we show the user the last chat they interacted with
+  def set_default_chat
+    @last_viewed_chat = Current.user&.last_viewed_chat
+    @chat = @last_viewed_chat
+  end
 
-    def set_active_storage_url_options
-      ActiveStorage::Current.url_options = {
-        protocol: request.protocol,
-        host: request.host,
-        port: request.optional_port
-      }
-    end
+  def set_active_storage_url_options
+    ActiveStorage::Current.url_options = {
+      protocol: request.protocol,
+      host: request.host,
+      port: request.optional_port
+    }
+  end
 end

--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -35,14 +35,14 @@ class BudgetCategoriesController < ApplicationController
   end
 
   private
-    def budget_category_params
-      params.require(:budget_category).permit(:budgeted_spending).tap do |params|
-        params[:budgeted_spending] = params[:budgeted_spending].presence || 0
-      end
+  def budget_category_params
+    params.require(:budget_category).permit(:budgeted_spending).tap do |params|
+      params[:budgeted_spending] = params[:budgeted_spending].presence || 0
     end
+  end
 
-    def set_budget
-      start_date = Budget.param_to_date(params[:budget_month_year])
-      @budget = Current.family.budgets.find_by(start_date: start_date)
-    end
+  def set_budget
+    start_date = Budget.param_to_date(params[:budget_month_year])
+    @budget = Current.family.budgets.find_by(start_date: start_date)
+  end
 end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -26,22 +26,22 @@ class BudgetsController < ApplicationController
 
   private
 
-    def budget_create_params
-      params.require(:budget).permit(:start_date)
-    end
+  def budget_create_params
+    params.require(:budget).permit(:start_date)
+  end
 
-    def budget_params
-      params.require(:budget).permit(:budgeted_spending, :expected_income)
-    end
+  def budget_params
+    params.require(:budget).permit(:budgeted_spending, :expected_income)
+  end
 
-    def set_budget
-      start_date = Budget.param_to_date(params[:month_year])
-      @budget = Budget.find_or_bootstrap(Current.family, start_date: start_date)
-      raise ActiveRecord::RecordNotFound unless @budget
-    end
+  def set_budget
+    start_date = Budget.param_to_date(params[:month_year])
+    @budget = Budget.find_or_bootstrap(Current.family, start_date: start_date)
+    raise ActiveRecord::RecordNotFound unless @budget
+  end
 
-    def redirect_to_current_month_budget
-      current_budget = Budget.find_or_bootstrap(Current.family, start_date: Date.current)
-      redirect_to budget_path(current_budget)
-    end
+  def redirect_to_current_month_budget
+    current_budget = Budget.find_or_bootstrap(Current.family, start_date: Date.current)
+    redirect_to budget_path(current_budget)
+  end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -68,25 +68,25 @@ class CategoriesController < ApplicationController
   end
 
   private
-    def set_category
-      @category = Current.family.categories.find(params[:id])
-    end
+  def set_category
+    @category = Current.family.categories.find(params[:id])
+  end
 
-    def set_categories
-      @categories = unless @category.parent?
-        Current.family.categories.alphabetically.roots.where.not(id: @category.id)
-      else
-        []
-      end
+  def set_categories
+    @categories = unless @category.parent?
+      Current.family.categories.alphabetically.roots.where.not(id: @category.id)
+    else
+      []
     end
+  end
 
-    def set_transaction
-      if params[:transaction_id].present?
-        @transaction = Current.family.transactions.find(params[:transaction_id])
-      end
+  def set_transaction
+    if params[:transaction_id].present?
+      @transaction = Current.family.transactions.find(params[:transaction_id])
     end
+  end
 
-    def category_params
-      params.require(:category).permit(:name, :color, :parent_id, :classification, :lucide_icon)
-    end
+  def category_params
+    params.require(:category).permit(:name, :color, :parent_id, :classification, :lucide_icon)
+  end
 end

--- a/app/controllers/category/deletions_controller.rb
+++ b/app/controllers/category/deletions_controller.rb
@@ -12,13 +12,13 @@ class Category::DeletionsController < ApplicationController
   end
 
   private
-    def set_category
-      @category = Current.family.categories.find(params[:category_id])
-    end
+  def set_category
+    @category = Current.family.categories.find(params[:category_id])
+  end
 
-    def set_replacement_category
-      if params[:replacement_category_id].present?
-        @replacement_category = Current.family.categories.find(params[:replacement_category_id])
-      end
+  def set_replacement_category
+    if params[:replacement_category_id].present?
+      @replacement_category = Current.family.categories.find(params[:replacement_category_id])
     end
+  end
 end

--- a/app/controllers/category/dropdowns_controller.rb
+++ b/app/controllers/category/dropdowns_controller.rb
@@ -6,17 +6,17 @@ class Category::DropdownsController < ApplicationController
   end
 
   private
-    def set_from_params
-      if params[:category_id]
-        @selected_category = categories_scope.find(params[:category_id])
-      end
-
-      if params[:transaction_id]
-        @transaction = Current.family.transactions.find(params[:transaction_id])
-      end
+  def set_from_params
+    if params[:category_id]
+      @selected_category = categories_scope.find(params[:category_id])
     end
 
-    def categories_scope
-      Current.family.categories.alphabetically
+    if params[:transaction_id]
+      @transaction = Current.family.transactions.find(params[:transaction_id])
     end
+  end
+
+  def categories_scope
+    Current.family.categories.alphabetically
+  end
 end

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -47,19 +47,19 @@ class ChatsController < ApplicationController
   end
 
   private
-    def set_chat
-      @chat = Current.user.chats.find(params[:id])
-    end
+  def set_chat
+    @chat = Current.user.chats.find(params[:id])
+  end
 
-    def set_last_viewed_chat(chat)
-      Current.user.update!(last_viewed_chat: chat)
-    end
+  def set_last_viewed_chat(chat)
+    Current.user.update!(last_viewed_chat: chat)
+  end
 
-    def clear_last_viewed_chat
-      Current.user.update!(last_viewed_chat: nil)
-    end
+  def clear_last_viewed_chat
+    Current.user.update!(last_viewed_chat: nil)
+  end
 
-    def chat_params
-      params.require(:chat).permit(:title, :content, :ai_model)
-    end
+  def chat_params
+    params.require(:chat).permit(:title, :content, :ai_model)
+  end
 end

--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -65,23 +65,23 @@ module AccountableResource
   end
 
   private
-    def set_link_options
-      @show_us_link = Current.family.can_connect_plaid_us?
-      @show_eu_link = Current.family.can_connect_plaid_eu?
-    end
+  def set_link_options
+    @show_us_link = Current.family.can_connect_plaid_us?
+    @show_eu_link = Current.family.can_connect_plaid_eu?
+  end
 
-    def accountable_type
-      controller_name.classify.constantize
-    end
+  def accountable_type
+    controller_name.classify.constantize
+  end
 
-    def set_account
-      @account = Current.family.accounts.find(params[:id])
-    end
+  def set_account
+    @account = Current.family.accounts.find(params[:id])
+  end
 
-    def account_params
-      params.require(:account).permit(
-        :name, :balance, :subtype, :currency, :accountable_type, :return_to,
-        accountable_attributes: self.class.permitted_accountable_attributes
-      )
-    end
+  def account_params
+    params.require(:account).permit(
+      :name, :balance, :subtype, :currency, :accountable_type, :return_to,
+      accountable_attributes: self.class.permitted_accountable_attributes
+    )
+  end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -15,53 +15,53 @@ module Authentication
   end
 
   private
-    def authenticate_user!
-      if session_record = find_session_by_cookie
-        Current.session = session_record
+  def authenticate_user!
+    if session_record = find_session_by_cookie
+      Current.session = session_record
+    else
+      if self_hosted_first_login?
+        redirect_to new_registration_url
       else
-        if self_hosted_first_login?
-          redirect_to new_registration_url
-        else
-          redirect_to new_session_url
-        end
+        redirect_to new_session_url
       end
     end
+  end
 
-    def find_session_by_cookie
-      cookie_value = cookies.signed[:session_token]
+  def find_session_by_cookie
+    cookie_value = cookies.signed[:session_token]
 
-      if cookie_value.present?
-        Session.find_by(id: cookie_value)
-      else
-        nil
-      end
+    if cookie_value.present?
+      Session.find_by(id: cookie_value)
+    else
+      nil
     end
+  end
 
-    def create_session_for(user)
-      session = user.sessions.create!
-      cookies.signed.permanent[:session_token] = { value: session.id, httponly: true }
-      session
+  def create_session_for(user)
+    session = user.sessions.create!
+    cookies.signed.permanent[:session_token] = { value: session.id, httponly: true }
+    session
+  end
+
+  def self_hosted_first_login?
+    Rails.application.config.app_mode.self_hosted? && User.count.zero?
+  end
+
+  def set_request_details
+    Current.user_agent = request.user_agent
+    Current.ip_address = request.ip
+  end
+
+  def set_sentry_user
+    return unless defined?(Sentry) && ENV["SENTRY_DSN"].present?
+
+    if Current.user
+      Sentry.set_user(
+        id: Current.user.id,
+        email: Current.user.email,
+        username: Current.user.display_name,
+        ip_address: Current.ip_address
+      )
     end
-
-    def self_hosted_first_login?
-      Rails.application.config.app_mode.self_hosted? && User.count.zero?
-    end
-
-    def set_request_details
-      Current.user_agent = request.user_agent
-      Current.ip_address = request.ip
-    end
-
-    def set_sentry_user
-      return unless defined?(Sentry) && ENV["SENTRY_DSN"].present?
-
-      if Current.user
-        Sentry.set_user(
-          id: Current.user.id,
-          email: Current.user.email,
-          username: Current.user.display_name,
-          ip_address: Current.ip_address
-        )
-      end
-    end
+  end
 end

--- a/app/controllers/concerns/auto_sync.rb
+++ b/app/controllers/concerns/auto_sync.rb
@@ -6,17 +6,17 @@ module AutoSync
   # end
 
   private
-    def sync_family
-      Current.family.sync_later
-    end
+  def sync_family
+    Current.family.sync_later
+  end
 
-    def family_needs_auto_sync?
-      return false unless Current.family&.accounts&.active&.any?
-      return false if (Current.family.last_sync_created_at&.to_date || 1.day.ago) >= Date.current
-      return false unless Current.family.auto_sync_on_login
+  def family_needs_auto_sync?
+    return false unless Current.family&.accounts&.active&.any?
+    return false if (Current.family.last_sync_created_at&.to_date || 1.day.ago) >= Date.current
+    return false unless Current.family.auto_sync_on_login
 
-      Rails.logger.info "Auto-syncing family #{Current.family.id}, last sync was #{Current.family.last_sync_created_at}"
+    Rails.logger.info "Auto-syncing family #{Current.family.id}, last sync was #{Current.family.last_sync_created_at}"
 
-      true
-    end
+    true
+  end
 end

--- a/app/controllers/concerns/breadcrumbable.rb
+++ b/app/controllers/concerns/breadcrumbable.rb
@@ -6,8 +6,8 @@ module Breadcrumbable
   end
 
   private
-    # The default, unless specific controller or action explicitly overrides
-    def set_breadcrumbs
-      @breadcrumbs = [["Home", root_path], [controller_name.titleize, nil]]
-    end
+  # The default, unless specific controller or action explicitly overrides
+  def set_breadcrumbs
+    @breadcrumbs = [["Home", root_path], [controller_name.titleize, nil]]
+  end
 end

--- a/app/controllers/concerns/entryable_resource.rb
+++ b/app/controllers/concerns/entryable_resource.rb
@@ -37,11 +37,11 @@ module EntryableResource
   end
 
   private
-    def entryable
-      controller_name.classify.constantize.new
-    end
+  def entryable
+    controller_name.classify.constantize.new
+  end
 
-    def set_entry
-      @entry = Current.family.entries.find(params[:id])
-    end
+  def set_entry
+    @entry = Current.family.entries.find(params[:id])
+  end
 end

--- a/app/controllers/concerns/feature_guardable.rb
+++ b/app/controllers/concerns/feature_guardable.rb
@@ -17,7 +17,7 @@ module FeatureGuardable
   end
 
   private
-    def guard_feature
-      render plain: "Feature disabled: #{controller_name}##{action_name}", status: :forbidden
-    end
+  def guard_feature
+    render plain: "Feature disabled: #{controller_name}##{action_name}", status: :forbidden
+  end
 end

--- a/app/controllers/concerns/impersonatable.rb
+++ b/app/controllers/concerns/impersonatable.rb
@@ -6,16 +6,16 @@ module Impersonatable
   end
 
   private
-    def create_impersonation_session_log
-      return unless Current.session&.active_impersonator_session.present?
+  def create_impersonation_session_log
+    return unless Current.session&.active_impersonator_session.present?
 
-      Current.session.active_impersonator_session.logs.create!(
-        controller: controller_name,
-        action: action_name,
-        path: request.fullpath,
-        method: request.method,
-        ip_address: request.ip,
-        user_agent: request.user_agent
-      )
-    end
+    Current.session.active_impersonator_session.logs.create!(
+      controller: controller_name,
+      action: action_name,
+      path: request.fullpath,
+      method: request.method,
+      ip_address: request.ip,
+      user_agent: request.user_agent
+    )
+  end
 end

--- a/app/controllers/concerns/invitable.rb
+++ b/app/controllers/concerns/invitable.rb
@@ -6,12 +6,12 @@ module Invitable
   end
 
   private
-    def invite_code_required?
-      return false if @invitation.present?
-      self_hosted? ? Setting.require_invite_for_signup : ENV["REQUIRE_INVITE_CODE"] == "true"
-    end
+  def invite_code_required?
+    return false if @invitation.present?
+    self_hosted? ? Setting.require_invite_for_signup : ENV["REQUIRE_INVITE_CODE"] == "true"
+  end
 
-    def self_hosted?
-      Rails.application.config.app_mode.self_hosted?
-    end
+  def self_hosted?
+    Rails.application.config.app_mode.self_hosted?
+  end
 end

--- a/app/controllers/concerns/localize.rb
+++ b/app/controllers/concerns/localize.rb
@@ -7,13 +7,13 @@ module Localize
   end
 
   private
-    def switch_locale(&action)
-      locale = Current.family.try(:locale) || I18n.default_locale
-      I18n.with_locale(locale, &action)
-    end
+  def switch_locale(&action)
+    locale = Current.family.try(:locale) || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
 
-    def switch_timezone(&action)
-      timezone = Current.family.try(:timezone) || Time.zone
-      Time.use_zone(timezone, &action)
-    end
+  def switch_timezone(&action)
+    timezone = Current.family.try(:timezone) || Time.zone
+    Time.use_zone(timezone, &action)
+  end
 end

--- a/app/controllers/concerns/notifiable.rb
+++ b/app/controllers/concerns/notifiable.rb
@@ -7,50 +7,50 @@ module Notifiable
   end
 
   private
-    def render_flash_notifications
-      notifications = flash.flat_map { |type, data| resolve_notifications(type, data) }.compact
+  def render_flash_notifications
+    notifications = flash.flat_map { |type, data| resolve_notifications(type, data) }.compact
 
-      view_context.safe_join(
-        notifications.map { |notification| view_context.render(**notification) }
-      )
-    end
+    view_context.safe_join(
+      notifications.map { |notification| view_context.render(**notification) }
+    )
+  end
 
-    def flash_notification_stream_items
-      items = flash.flat_map do |type, data|
-        notifications = resolve_notifications(type, data)
+  def flash_notification_stream_items
+    items = flash.flat_map do |type, data|
+      notifications = resolve_notifications(type, data)
 
-        if type == "cta"
-          notifications.map { |notification| turbo_stream.replace("cta", **notification) }
-        else
-          notifications.map { |notification| turbo_stream.append("notification-tray", **notification) }
-        end
-      end.compact
-
-      # If rendering flash notifications via stream, we mark them as used to avoid
-      # them being rendered again on the next page load
-      flash.clear
-
-      items
-    end
-
-    def resolve_cta(cta)
-      case cta[:type]
-      when "category_rule"
-        { partial: "rules/category_rule_cta", locals: { cta: } }
-      end
-    end
-
-    def resolve_notifications(type, data)
-      case type
-      when "alert"
-        [{ partial: "shared/notifications/alert", locals: { message: data } }]
-      when "cta"
-        [resolve_cta(data)]
-      when "notice"
-        messages = Array(data)
-        messages.map { |message| { partial: "shared/notifications/notice", locals: { message: message } } }
+      if type == "cta"
+        notifications.map { |notification| turbo_stream.replace("cta", **notification) }
       else
-        []
+        notifications.map { |notification| turbo_stream.append("notification-tray", **notification) }
       end
+    end.compact
+
+    # If rendering flash notifications via stream, we mark them as used to avoid
+    # them being rendered again on the next page load
+    flash.clear
+
+    items
+  end
+
+  def resolve_cta(cta)
+    case cta[:type]
+    when "category_rule"
+      { partial: "rules/category_rule_cta", locals: { cta: } }
     end
+  end
+
+  def resolve_notifications(type, data)
+    case type
+    when "alert"
+      [{ partial: "shared/notifications/alert", locals: { message: data } }]
+    when "cta"
+      [resolve_cta(data)]
+    when "notice"
+      messages = Array(data)
+      messages.map { |message| { partial: "shared/notifications/notice", locals: { message: message } } }
+    else
+      []
+    end
+  end
 end

--- a/app/controllers/concerns/onboardable.rb
+++ b/app/controllers/concerns/onboardable.rb
@@ -6,33 +6,33 @@ module Onboardable
   end
 
   private
-    # First, we require onboarding, then once that's complete, we require an upgrade for non-subscribed users.
-    def require_onboarding_and_upgrade
-      return unless Current.user
-      return unless redirectable_path?(request.path)
+  # First, we require onboarding, then once that's complete, we require an upgrade for non-subscribed users.
+  def require_onboarding_and_upgrade
+    return unless Current.user
+    return unless redirectable_path?(request.path)
 
-      if Current.user.needs_onboarding?
-        redirect_to onboarding_path
-      elsif Current.family.needs_subscription?
-        redirect_to trial_onboarding_path
-      elsif Current.family.upgrade_required?
-        redirect_to upgrade_subscription_path
-      end
+    if Current.user.needs_onboarding?
+      redirect_to onboarding_path
+    elsif Current.family.needs_subscription?
+      redirect_to trial_onboarding_path
+    elsif Current.family.upgrade_required?
+      redirect_to upgrade_subscription_path
     end
+  end
 
-    def redirectable_path?(path)
-      return false if path.starts_with?("/settings")
-      return false if path.starts_with?("/subscription")
-      return false if path.starts_with?("/onboarding")
-      return false if path.starts_with?("/users")
-      return false if path.starts_with?("/api")  # Exclude API endpoints from onboarding redirects
-      return false if path.starts_with?("/jobs")
+  def redirectable_path?(path)
+    return false if path.starts_with?("/settings")
+    return false if path.starts_with?("/subscription")
+    return false if path.starts_with?("/onboarding")
+    return false if path.starts_with?("/users")
+    return false if path.starts_with?("/api")  # Exclude API endpoints from onboarding redirects
+    return false if path.starts_with?("/jobs")
 
-      [
-        new_registration_path,
-        new_session_path,
-        new_password_reset_path,
-        new_email_confirmation_path
-      ].exclude?(path)
-    end
+    [
+      new_registration_path,
+      new_session_path,
+      new_password_reset_path,
+      new_email_confirmation_path
+    ].exclude?(path)
+  end
 end

--- a/app/controllers/concerns/periodable.rb
+++ b/app/controllers/concerns/periodable.rb
@@ -6,9 +6,9 @@ module Periodable
   end
 
   private
-    def set_period
-      @period = Period.from_key(params[:period] || Current.user&.default_period)
-    rescue Period::InvalidKeyError
-      @period = Period.last_30_days
-    end
+  def set_period
+    @period = Period.from_key(params[:period] || Current.user&.default_period)
+  rescue Period::InvalidKeyError
+    @period = Period.last_30_days
+  end
 end

--- a/app/controllers/concerns/restore_layout_preferences.rb
+++ b/app/controllers/concerns/restore_layout_preferences.rb
@@ -6,19 +6,19 @@ module RestoreLayoutPreferences
   end
 
   private
-    def restore_active_tabs
-      last_selected_tab = Current.session&.get_preferred_tab("account_sidebar_tab") || "asset"
+  def restore_active_tabs
+    last_selected_tab = Current.session&.get_preferred_tab("account_sidebar_tab") || "asset"
 
-      @account_group_tab = account_group_tab_param || last_selected_tab
-    end
+    @account_group_tab = account_group_tab_param || last_selected_tab
+  end
 
-    def valid_account_group_tabs
-      %w[asset liability all]
-    end
+  def valid_account_group_tabs
+    %w[asset liability all]
+  end
 
-    def account_group_tab_param
-      param_value = params[:account_sidebar_tab]
-      return nil unless param_value.in?(valid_account_group_tabs)
-      param_value
-    end
+  def account_group_tab_param
+    param_value = params[:account_sidebar_tab]
+    return nil unless param_value.in?(valid_account_group_tabs)
+    param_value
+  end
 end

--- a/app/controllers/concerns/self_hostable.rb
+++ b/app/controllers/concerns/self_hostable.rb
@@ -6,11 +6,11 @@ module SelfHostable
   end
 
   private
-    def self_hosted?
-      Rails.configuration.app_mode.self_hosted?
-    end
+  def self_hosted?
+    Rails.configuration.app_mode.self_hosted?
+  end
 
-    def self_hosted_first_login?
-      self_hosted? && User.count.zero?
-    end
+  def self_hosted_first_login?
+    self_hosted? && User.count.zero?
+  end
 end

--- a/app/controllers/concerns/stream_extensions.rb
+++ b/app/controllers/concerns/stream_extensions.rb
@@ -10,11 +10,11 @@ module StreamExtensions
   end
 
   private
-    def custom_stream_redirect(path, redirect_back: false, notice: nil, alert: nil)
-      flash[:notice] = notice if notice.present?
-      flash[:alert] = alert if alert.present?
+  def custom_stream_redirect(path, redirect_back: false, notice: nil, alert: nil)
+    flash[:notice] = notice if notice.present?
+    flash[:alert] = alert if alert.present?
 
-      redirect_target_url = redirect_back ? request.referer : path
-      render turbo_stream: turbo_stream.action(:redirect, redirect_target_url)
-    end
+    redirect_target_url = redirect_back ? request.referer : path
+    render turbo_stream: turbo_stream.action(:redirect, redirect_target_url)
+  end
 end

--- a/app/controllers/cookie_sessions_controller.rb
+++ b/app/controllers/cookie_sessions_controller.rb
@@ -9,14 +9,14 @@ class CookieSessionsController < ApplicationController
   end
 
   private
-    def cookie_session_params
-      params.require(:cookie_session).permit(:tab_key, :tab_value)
-    end
+  def cookie_session_params
+    params.require(:cookie_session).permit(:tab_key, :tab_value)
+  end
 
-    def save_kv_to_session(key, value)
-      raise "Key must be a string" unless key.is_a?(String)
-      raise "Value must be a string" unless value.is_a?(String)
+  def save_kv_to_session(key, value)
+    raise "Key must be a string" unless key.is_a?(String)
+    raise "Value must be a string" unless value.is_a?(String)
 
-      session["custom_#{key}"] = value
-    end
+    session["custom_#{key}"] = value
+  end
 end

--- a/app/controllers/current_sessions_controller.rb
+++ b/app/controllers/current_sessions_controller.rb
@@ -8,7 +8,7 @@ class CurrentSessionsController < ApplicationController
   end
 
   private
-    def session_params
-      params.require(:current_session).permit(:tab_key, :tab_value)
-    end
+  def session_params
+    params.require(:current_session).permit(:tab_key, :tab_value)
+  end
 end

--- a/app/controllers/family_exports_controller.rb
+++ b/app/controllers/family_exports_controller.rb
@@ -35,13 +35,13 @@ class FamilyExportsController < ApplicationController
 
   private
 
-    def set_export
-      @export = Current.family.family_exports.find(params[:id])
-    end
+  def set_export
+    @export = Current.family.family_exports.find(params[:id])
+  end
 
-    def require_admin
-      unless Current.user.admin?
-        redirect_to root_path, alert: "Access denied"
-      end
+  def require_admin
+    unless Current.user.admin?
+      redirect_to root_path, alert: "Access denied"
     end
+  end
 end

--- a/app/controllers/family_merchants_controller.rb
+++ b/app/controllers/family_merchants_controller.rb
@@ -43,11 +43,11 @@ class FamilyMerchantsController < ApplicationController
   end
 
   private
-    def set_merchant
-      @family_merchant = Current.family.merchants.find(params[:id])
-    end
+  def set_merchant
+    @family_merchant = Current.family.merchants.find(params[:id])
+  end
 
-    def merchant_params
-      params.require(:family_merchant).permit(:name, :color)
-    end
+  def merchant_params
+    params.require(:family_merchant).permit(:name, :color)
+  end
 end

--- a/app/controllers/holdings_controller.rb
+++ b/app/controllers/holdings_controller.rb
@@ -23,7 +23,7 @@ class HoldingsController < ApplicationController
   end
 
   private
-    def set_holding
-      @holding = Current.family.holdings.find(params[:id])
-    end
+  def set_holding
+    @holding = Current.family.holdings.find(params[:id])
+  end
 end

--- a/app/controllers/impersonation_sessions_controller.rb
+++ b/app/controllers/impersonation_sessions_controller.rb
@@ -38,21 +38,21 @@ class ImpersonationSessionsController < ApplicationController
   end
 
   private
-    def session_params
-      params.require(:impersonation_session).permit(:impersonated_id)
-    end
+  def session_params
+    params.require(:impersonation_session).permit(:impersonated_id)
+  end
 
-    def set_impersonation_session
-      @impersonation_session =
-        Current.true_user.impersonated_support_sessions.find_by(id: params[:id]) ||
-        Current.true_user.impersonator_support_sessions.find_by(id: params[:id])
-    end
+  def set_impersonation_session
+    @impersonation_session =
+      Current.true_user.impersonated_support_sessions.find_by(id: params[:id]) ||
+      Current.true_user.impersonator_support_sessions.find_by(id: params[:id])
+  end
 
-    def require_super_admin!
-      raise_unauthorized! unless Current.true_user&.super_admin?
-    end
+  def require_super_admin!
+    raise_unauthorized! unless Current.true_user&.super_admin?
+  end
 
-    def raise_unauthorized!
-      raise ActionController::RoutingError.new("Not Found")
-    end
+  def raise_unauthorized!
+    raise ActionController::RoutingError.new("Not Found")
+  end
 end

--- a/app/controllers/import/cleans_controller.rb
+++ b/app/controllers/import/cleans_controller.rb
@@ -16,7 +16,7 @@ class Import::CleansController < ApplicationController
   end
 
   private
-    def set_import
-      @import = Current.family.imports.find(params[:import_id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:import_id])
+  end
 end

--- a/app/controllers/import/configurations_controller.rb
+++ b/app/controllers/import/configurations_controller.rb
@@ -15,30 +15,30 @@ class Import::ConfigurationsController < ApplicationController
   end
 
   private
-    def set_import
-      @import = Current.family.imports.find(params[:import_id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:import_id])
+  end
 
-    def import_params
-      params.require(:import).permit(
-        :date_col_label,
-        :amount_col_label,
-        :name_col_label,
-        :category_col_label,
-        :tags_col_label,
-        :account_col_label,
-        :qty_col_label,
-        :ticker_col_label,
-        :exchange_operating_mic_col_label,
-        :price_col_label,
-        :entity_type_col_label,
-        :notes_col_label,
-        :currency_col_label,
-        :date_format,
-        :number_format,
-        :signage_convention,
-        :amount_type_strategy,
-        :amount_type_inflow_value,
-      )
-    end
+  def import_params
+    params.require(:import).permit(
+      :date_col_label,
+      :amount_col_label,
+      :name_col_label,
+      :category_col_label,
+      :tags_col_label,
+      :account_col_label,
+      :qty_col_label,
+      :ticker_col_label,
+      :exchange_operating_mic_col_label,
+      :price_col_label,
+      :entity_type_col_label,
+      :notes_col_label,
+      :currency_col_label,
+      :date_format,
+      :number_format,
+      :signage_convention,
+      :amount_type_strategy,
+      :amount_type_inflow_value,
+    )
+  end
 end

--- a/app/controllers/import/confirms_controller.rb
+++ b/app/controllers/import/confirms_controller.rb
@@ -12,7 +12,7 @@ class Import::ConfirmsController < ApplicationController
   end
 
   private
-    def set_import
-      @import = Current.family.imports.find(params[:import_id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:import_id])
+  end
 end

--- a/app/controllers/import/mappings_controller.rb
+++ b/app/controllers/import/mappings_controller.rb
@@ -13,31 +13,31 @@ class Import::MappingsController < ApplicationController
   end
 
   private
-    def mapping_params
-      params.require(:import_mapping).permit(:type, :key, :mappable_id, :mappable_type, :value)
-    end
+  def mapping_params
+    params.require(:import_mapping).permit(:type, :key, :mappable_id, :mappable_type, :value)
+  end
 
-    def set_import
-      @import = Current.family.imports.find(params[:import_id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:import_id])
+  end
 
-    def mappable
-      return nil unless mappable_class.present?
+  def mappable
+    return nil unless mappable_class.present?
 
-      @mappable ||= mappable_class.find_by(id: mapping_params[:mappable_id], family: Current.family)
-    end
+    @mappable ||= mappable_class.find_by(id: mapping_params[:mappable_id], family: Current.family)
+  end
 
-    def create_when_empty
-      return false unless mapping_class.present?
+  def create_when_empty
+    return false unless mapping_class.present?
 
-      mapping_params[:mappable_id] == mapping_class::CREATE_NEW_KEY
-    end
+    mapping_params[:mappable_id] == mapping_class::CREATE_NEW_KEY
+  end
 
-    def mappable_class
-      mapping_params[:mappable_type]&.constantize
-    end
+  def mappable_class
+    mapping_params[:mappable_type]&.constantize
+  end
 
-    def mapping_class
-      mapping_params[:type]&.constantize
-    end
+  def mapping_class
+    mapping_params[:type]&.constantize
+  end
 end

--- a/app/controllers/import/rows_controller.rb
+++ b/app/controllers/import/rows_controller.rb
@@ -11,12 +11,12 @@ class Import::RowsController < ApplicationController
   end
 
   private
-    def row_params
-      params.require(:import_row).permit(:type, :account, :date, :qty, :ticker, :price, :amount, :currency, :name, :category, :tags, :entity_type, :notes)
-    end
+  def row_params
+    params.require(:import_row).permit(:type, :account, :date, :qty, :ticker, :price, :amount, :currency, :name, :category, :tags, :entity_type, :notes)
+  end
 
-    def set_import_row
-      @import = Current.family.imports.find(params[:import_id])
-      @row = @import.rows.find(params[:id])
-    end
+  def set_import_row
+    @import = Current.family.imports.find(params[:import_id])
+    @row = @import.rows.find(params[:id])
+  end
 end

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -28,26 +28,26 @@ class Import::UploadsController < ApplicationController
   end
 
   private
-    def set_import
-      @import = Current.family.imports.find(params[:import_id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:import_id])
+  end
 
-    def csv_str
-      @csv_str ||= upload_params[:csv_file]&.read || upload_params[:raw_file_str]
-    end
+  def csv_str
+    @csv_str ||= upload_params[:csv_file]&.read || upload_params[:raw_file_str]
+  end
 
-    def csv_valid?(str)
-      begin
-        csv = Import.parse_csv_str(str, col_sep: upload_params[:col_sep])
-        return false if csv.headers.empty?
-        return false if csv.count == 0
-        true
-      rescue CSV::MalformedCSVError
-        false
-      end
+  def csv_valid?(str)
+    begin
+      csv = Import.parse_csv_str(str, col_sep: upload_params[:col_sep])
+      return false if csv.headers.empty?
+      return false if csv.count == 0
+      true
+    rescue CSV::MalformedCSVError
+      false
     end
+  end
 
-    def upload_params
-      params.require(:import).permit(:raw_file_str, :csv_file, :col_sep)
-    end
+  def upload_params
+    params.require(:import).permit(:raw_file_str, :csv_file, :col_sep)
+  end
 end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -59,11 +59,11 @@ class ImportsController < ApplicationController
   end
 
   private
-    def set_import
-      @import = Current.family.imports.find(params[:id])
-    end
+  def set_import
+    @import = Current.family.imports.find(params[:id])
+  end
 
-    def import_params
-      params.require(:import).permit(:type)
-    end
+  def import_params
+    params.require(:import).permit(:type)
+  end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -54,7 +54,7 @@ class InvitationsController < ApplicationController
 
   private
 
-    def invitation_params
-      params.require(:invitation).permit(:email, :role)
-    end
+  def invitation_params
+    params.require(:invitation).permit(:email, :role)
+  end
 end

--- a/app/controllers/invite_codes_controller.rb
+++ b/app/controllers/invite_codes_controller.rb
@@ -13,7 +13,7 @@ class InviteCodesController < ApplicationController
 
   private
 
-    def ensure_self_hosted
-      redirect_to root_path unless self_hosted?
-    end
+  def ensure_self_hosted
+    redirect_to root_path unless self_hosted?
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,11 +14,11 @@ class MessagesController < ApplicationController
   end
 
   private
-    def set_chat
-      @chat = Current.user.chats.find(params[:chat_id])
-    end
+  def set_chat
+    @chat = Current.user.chats.find(params[:chat_id])
+  end
 
-    def message_params
-      params.require(:message).permit(:content, :ai_model)
-    end
+  def message_params
+    params.require(:message).permit(:content, :ai_model)
+  end
 end

--- a/app/controllers/mfa_controller.rb
+++ b/app/controllers/mfa_controller.rb
@@ -46,11 +46,11 @@ class MfaController < ApplicationController
 
   private
 
-    def determine_layout
-      if action_name.in?(%w[verify verify_code])
-        "auth"
-      else
-        "settings"
-      end
+  def determine_layout
+    if action_name.in?(%w[verify verify_code])
+      "auth"
+    else
+      "settings"
     end
+  end
 end

--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -14,11 +14,11 @@ class OnboardingsController < ApplicationController
   end
 
   private
-    def set_user
-      @user = Current.user
-    end
+  def set_user
+    @user = Current.user
+  end
 
-    def load_invitation
-      @invitation = Current.family.invitations.accepted.find_by(email: Current.user.email)
-    end
+  def load_invitation
+    @invitation = Current.family.invitations.accepted.find_by(email: Current.user.email)
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -47,103 +47,103 @@ class PagesController < ApplicationController
   end
 
   private
-    def github_provider
-      Provider::Registry.get_provider(:github)
-    end
+  def github_provider
+    Provider::Registry.get_provider(:github)
+  end
 
-    def build_cashflow_sankey_data(income_totals, expense_totals, currency_symbol)
-      nodes = []
-      links = []
-      node_indices = {} # Memoize node indices by a unique key: "type_categoryid"
+  def build_cashflow_sankey_data(income_totals, expense_totals, currency_symbol)
+    nodes = []
+    links = []
+    node_indices = {} # Memoize node indices by a unique key: "type_categoryid"
 
-      # Helper to add/find node and return its index
-      add_node = ->(unique_key, display_name, value, percentage, color) {
-        node_indices[unique_key] ||= begin
-          nodes << { name: display_name, value: value.to_f.round(2), percentage: percentage.to_f.round(1), color: color }
-          nodes.size - 1
-        end
+    # Helper to add/find node and return its index
+    add_node = ->(unique_key, display_name, value, percentage, color) {
+      node_indices[unique_key] ||= begin
+        nodes << { name: display_name, value: value.to_f.round(2), percentage: percentage.to_f.round(1), color: color }
+        nodes.size - 1
+      end
+    }
+
+    total_income_val = income_totals.total.to_f.round(2)
+    total_expense_val = expense_totals.total.to_f.round(2)
+
+    # --- Create Central Cash Flow Node ---
+    cash_flow_idx = add_node.call("cash_flow_node", "Cash Flow", total_income_val, 0, "var(--color-success)")
+
+    # --- Process Income Side (Top-level categories only) ---
+    income_totals.category_totals.each do |ct|
+      # Skip subcategories – only include root income categories
+      next if ct.category.parent_id.present?
+
+      val = ct.total.to_f.round(2)
+      next if val.zero?
+
+      percentage_of_total_income = total_income_val.zero? ? 0 : (val / total_income_val * 100).round(1)
+
+      node_display_name = ct.category.name
+      node_color = ct.category.color.presence || Category::COLORS.sample
+
+      current_cat_idx = add_node.call(
+        "income_#{ct.category.id}",
+        node_display_name,
+        val,
+        percentage_of_total_income,
+        node_color
+      )
+
+      links << {
+        source: current_cat_idx,
+        target: cash_flow_idx,
+        value: val,
+        color: node_color,
+        percentage: percentage_of_total_income
       }
-
-      total_income_val = income_totals.total.to_f.round(2)
-      total_expense_val = expense_totals.total.to_f.round(2)
-
-      # --- Create Central Cash Flow Node ---
-      cash_flow_idx = add_node.call("cash_flow_node", "Cash Flow", total_income_val, 0, "var(--color-success)")
-
-      # --- Process Income Side (Top-level categories only) ---
-      income_totals.category_totals.each do |ct|
-        # Skip subcategories – only include root income categories
-        next if ct.category.parent_id.present?
-
-        val = ct.total.to_f.round(2)
-        next if val.zero?
-
-        percentage_of_total_income = total_income_val.zero? ? 0 : (val / total_income_val * 100).round(1)
-
-        node_display_name = ct.category.name
-        node_color = ct.category.color.presence || Category::COLORS.sample
-
-        current_cat_idx = add_node.call(
-          "income_#{ct.category.id}",
-          node_display_name,
-          val,
-          percentage_of_total_income,
-          node_color
-        )
-
-        links << {
-          source: current_cat_idx,
-          target: cash_flow_idx,
-          value: val,
-          color: node_color,
-          percentage: percentage_of_total_income
-        }
-      end
-
-      # --- Process Expense Side (Top-level categories only) ---
-      expense_totals.category_totals.each do |ct|
-        # Skip subcategories – only include root expense categories to keep Sankey shallow
-        next if ct.category.parent_id.present?
-
-        val = ct.total.to_f.round(2)
-        next if val.zero?
-
-        percentage_of_total_expense = total_expense_val.zero? ? 0 : (val / total_expense_val * 100).round(1)
-
-        node_display_name = ct.category.name
-        node_color = ct.category.color.presence || Category::UNCATEGORIZED_COLOR
-
-        current_cat_idx = add_node.call(
-          "expense_#{ct.category.id}",
-          node_display_name,
-          val,
-          percentage_of_total_expense,
-          node_color
-        )
-
-        links << {
-          source: cash_flow_idx,
-          target: current_cat_idx,
-          value: val,
-          color: node_color,
-          percentage: percentage_of_total_expense
-        }
-      end
-
-      # --- Process Surplus ---
-      leftover = (total_income_val - total_expense_val).round(2)
-      if leftover.positive?
-        percentage_of_total_income_for_surplus = total_income_val.zero? ? 0 : (leftover / total_income_val * 100).round(1)
-        surplus_idx = add_node.call("surplus_node", "Surplus", leftover, percentage_of_total_income_for_surplus, "var(--color-success)")
-        links << { source: cash_flow_idx, target: surplus_idx, value: leftover, color: "var(--color-success)", percentage: percentage_of_total_income_for_surplus }
-      end
-
-      # Update Cash Flow and Income node percentages (relative to total income)
-      if node_indices["cash_flow_node"]
-        nodes[node_indices["cash_flow_node"]][:percentage] = 100.0
-      end
-      # No primary income node anymore, percentages are on individual income cats relative to total_income_val
-
-      { nodes: nodes, links: links, currency_symbol: Money::Currency.new(currency_symbol).symbol }
     end
+
+    # --- Process Expense Side (Top-level categories only) ---
+    expense_totals.category_totals.each do |ct|
+      # Skip subcategories – only include root expense categories to keep Sankey shallow
+      next if ct.category.parent_id.present?
+
+      val = ct.total.to_f.round(2)
+      next if val.zero?
+
+      percentage_of_total_expense = total_expense_val.zero? ? 0 : (val / total_expense_val * 100).round(1)
+
+      node_display_name = ct.category.name
+      node_color = ct.category.color.presence || Category::UNCATEGORIZED_COLOR
+
+      current_cat_idx = add_node.call(
+        "expense_#{ct.category.id}",
+        node_display_name,
+        val,
+        percentage_of_total_expense,
+        node_color
+      )
+
+      links << {
+        source: cash_flow_idx,
+        target: current_cat_idx,
+        value: val,
+        color: node_color,
+        percentage: percentage_of_total_expense
+      }
+    end
+
+    # --- Process Surplus ---
+    leftover = (total_income_val - total_expense_val).round(2)
+    if leftover.positive?
+      percentage_of_total_income_for_surplus = total_income_val.zero? ? 0 : (leftover / total_income_val * 100).round(1)
+      surplus_idx = add_node.call("surplus_node", "Surplus", leftover, percentage_of_total_income_for_surplus, "var(--color-success)")
+      links << { source: cash_flow_idx, target: surplus_idx, value: leftover, color: "var(--color-success)", percentage: percentage_of_total_income_for_surplus }
+    end
+
+    # Update Cash Flow and Income node percentages (relative to total income)
+    if node_indices["cash_flow_node"]
+      nodes[node_indices["cash_flow_node"]][:percentage] = 100.0
+    end
+    # No primary income node anymore, percentages are on individual income cats relative to total_income_val
+
+    { nodes: nodes, links: links, currency_symbol: Money::Currency.new(currency_symbol).symbol }
+  end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -33,12 +33,12 @@ class PasswordResetsController < ApplicationController
 
   private
 
-    def set_user_by_token
-      @user = User.find_by_token_for(:password_reset, params[:token])
-      redirect_to new_password_reset_path, alert: t("password_resets.update.invalid_token") unless @user.present?
-    end
+  def set_user_by_token
+    @user = User.find_by_token_for(:password_reset, params[:token])
+    redirect_to new_password_reset_path, alert: t("password_resets.update.invalid_token") unless @user.present?
+  end
 
-    def password_params
-      params.require(:user).permit(:password, :password_confirmation)
-    end
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -12,7 +12,7 @@ class PasswordsController < ApplicationController
 
   private
 
-    def password_params
-      params.require(:user).permit(:password, :password_confirmation, :password_challenge).with_defaults(password_challenge: "")
-    end
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation, :password_challenge).with_defaults(password_challenge: "")
+  end
 end

--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -49,27 +49,27 @@ class PlaidItemsController < ApplicationController
   end
 
   private
-    def set_plaid_item
-      @plaid_item = Current.family.plaid_items.find(params[:id])
-    end
+  def set_plaid_item
+    @plaid_item = Current.family.plaid_items.find(params[:id])
+  end
 
-    def plaid_item_params
-      params.require(:plaid_item).permit(:public_token, :region, metadata: {})
-    end
+  def plaid_item_params
+    params.require(:plaid_item).permit(:public_token, :region, metadata: {})
+  end
 
-    def item_name
-      plaid_item_params.dig(:metadata, :institution, :name)
-    end
+  def item_name
+    plaid_item_params.dig(:metadata, :institution, :name)
+  end
 
-    def plaid_us_webhooks_url
-      return webhooks_plaid_url if Rails.env.production?
+  def plaid_us_webhooks_url
+    return webhooks_plaid_url if Rails.env.production?
 
-      ENV.fetch("DEV_WEBHOOKS_URL", root_url.chomp("/")) + "/webhooks/plaid"
-    end
+    ENV.fetch("DEV_WEBHOOKS_URL", root_url.chomp("/")) + "/webhooks/plaid"
+  end
 
-    def plaid_eu_webhooks_url
-      return webhooks_plaid_eu_url if Rails.env.production?
+  def plaid_eu_webhooks_url
+    return webhooks_plaid_eu_url if Rails.env.production?
 
-      ENV.fetch("DEV_WEBHOOKS_URL", root_url.chomp("/")) + "/webhooks/plaid_eu"
-    end
+    ENV.fetch("DEV_WEBHOOKS_URL", root_url.chomp("/")) + "/webhooks/plaid_eu"
+  end
 end

--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -24,7 +24,7 @@ class PricesController < ApplicationController
 
   private
 
-    def create_params
-      params.require(:model).permit(:security_id, :date, :price, :currency)
-    end
+  def create_params
+    params.require(:model).permit(:security_id, :date, :price, :currency)
+  end
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -78,22 +78,22 @@ class PropertiesController < ApplicationController
   end
 
   private
-    def balance_params
-      params.require(:account).permit(:balance, :currency)
-    end
+  def balance_params
+    params.require(:account).permit(:balance, :currency)
+  end
 
-    def address_params
-      params.require(:property)
-            .permit(address_attributes: [:line1, :line2, :locality, :region, :country, :postal_code])
-    end
+  def address_params
+    params.require(:property)
+          .permit(address_attributes: [:line1, :line2, :locality, :region, :country, :postal_code])
+  end
 
-    def property_params
-      params.require(:account)
-            .permit(:name, :subtype, :accountable_type, accountable_attributes: [:id, :year_built, :area_unit, :area_value])
-    end
+  def property_params
+    params.require(:account)
+          .permit(:name, :subtype, :accountable_type, accountable_attributes: [:id, :year_built, :area_unit, :area_value])
+  end
 
-    def set_property
-      @account = Current.family.accounts.find(params[:id])
-      @property = @account.property
-    end
+  def set_property
+    @account = Current.family.accounts.find(params[:id])
+    @property = @account.property
+  end
 end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -65,20 +65,20 @@ class RulesController < ApplicationController
   end
 
   private
-    def set_rule
-      @rule = Current.family.rules.find(params[:id])
-    end
+  def set_rule
+    @rule = Current.family.rules.find(params[:id])
+  end
 
-    def rule_params
-      params.require(:rule).permit(
-        :resource_type, :effective_date, :active, :name,
-        conditions_attributes: [
-          :id, :condition_type, :operator, :value, :_destroy,
-          sub_conditions_attributes: [:id, :condition_type, :operator, :value, :_destroy]
-        ],
-        actions_attributes: [
-          :id, :action_type, :value, :_destroy
-        ]
-      )
-    end
+  def rule_params
+    params.require(:rule).permit(
+      :resource_type, :effective_date, :active, :name,
+      conditions_attributes: [
+        :id, :condition_type, :operator, :value, :_destroy,
+        sub_conditions_attributes: [:id, :condition_type, :operator, :value, :_destroy]
+      ],
+      actions_attributes: [
+        :id, :action_type, :value, :_destroy
+      ]
+    )
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
   end
 
   private
-    def set_session
-      @session = Current.user.sessions.find(params[:id])
-    end
+  def set_session
+    @session = Current.user.sessions.find(params[:id])
+  end
 end

--- a/app/controllers/settings/api_keys_controller.rb
+++ b/app/controllers/settings/api_keys_controller.rb
@@ -46,16 +46,16 @@ class Settings::ApiKeysController < ApplicationController
 
   private
 
-    def set_api_key
-      @api_key = Current.user.api_keys.active.first
-    end
+  def set_api_key
+    @api_key = Current.user.api_keys.active.first
+  end
 
-    def api_key_params
-      # Convert single scope value to array for storage
-      permitted_params = params.require(:api_key).permit(:name, :scopes)
-      if permitted_params[:scopes].present?
-        permitted_params[:scopes] = [permitted_params[:scopes]]
-      end
-      permitted_params
+  def api_key_params
+    # Convert single scope value to array for storage
+    permitted_params = params.require(:api_key).permit(:name, :scopes)
+    if permitted_params[:scopes].present?
+      permitted_params[:scopes] = [permitted_params[:scopes]]
     end
+    permitted_params
+  end
 end

--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -35,11 +35,11 @@ class Settings::HostingsController < ApplicationController
   end
 
   private
-    def hosting_params
-      params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :synth_api_key)
-    end
+  def hosting_params
+    params.require(:setting).permit(:require_invite_for_signup, :require_email_confirmation, :synth_api_key)
+  end
 
-    def ensure_admin
-      redirect_to settings_hosting_path, alert: t(".not_authorized") unless Current.user.admin?
-    end
+  def ensure_admin
+    redirect_to settings_hosting_path, alert: t(".not_authorized") unless Current.user.admin?
+  end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -58,7 +58,7 @@ class SubscriptionsController < ApplicationController
   end
 
   private
-    def stripe
-      @stripe ||= Provider::Registry.get_provider(:stripe)
-    end
+  def stripe
+    @stripe ||= Provider::Registry.get_provider(:stripe)
+  end
 end

--- a/app/controllers/tag/deletions_controller.rb
+++ b/app/controllers/tag/deletions_controller.rb
@@ -12,11 +12,11 @@ class Tag::DeletionsController < ApplicationController
 
   private
 
-    def set_tag
-      @tag = Current.family.tags.find_by(id: params[:tag_id])
-    end
+  def set_tag
+    @tag = Current.family.tags.find_by(id: params[:tag_id])
+  end
 
-    def set_replacement_tag
-      @replacement_tag = Current.family.tags.find_by(id: params[:replacement_tag_id])
-    end
+  def set_replacement_tag
+    @replacement_tag = Current.family.tags.find_by(id: params[:replacement_tag_id])
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -41,11 +41,11 @@ class TagsController < ApplicationController
 
   private
 
-    def set_tag
-      @tag = Current.family.tags.find(params[:id])
-    end
+  def set_tag
+    @tag = Current.family.tags.find(params[:id])
+  end
 
-    def tag_params
-      params.require(:tag).permit(:name, :color)
-    end
+  def tag_params
+    params.require(:tag).permit(:name, :color)
+  end
 end

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -51,34 +51,34 @@ class TradesController < ApplicationController
   end
 
   private
-    def entry_params
-      params.require(:entry).permit(
-        :name, :date, :amount, :currency, :excluded, :notes, :nature,
-        entryable_attributes: [:id, :qty, :price]
-      )
+  def entry_params
+    params.require(:entry).permit(
+      :name, :date, :amount, :currency, :excluded, :notes, :nature,
+      entryable_attributes: [:id, :qty, :price]
+    )
+  end
+
+  def create_params
+    params.require(:model).permit(
+      :date, :amount, :currency, :qty, :price, :ticker, :manual_ticker, :type, :transfer_account_id
+    )
+  end
+
+  def update_entry_params
+    return entry_params unless entry_params[:entryable_attributes].present?
+
+    update_params = entry_params
+    update_params = update_params.merge(entryable_type: "Trade")
+
+    qty = update_params[:entryable_attributes][:qty]
+    price = update_params[:entryable_attributes][:price]
+
+    if qty.present? && price.present?
+      qty = update_params[:nature] == "inflow" ? -qty.to_d : qty.to_d
+      update_params[:entryable_attributes][:qty] = qty
+      update_params[:amount] = qty * price.to_d
     end
 
-    def create_params
-      params.require(:model).permit(
-        :date, :amount, :currency, :qty, :price, :ticker, :manual_ticker, :type, :transfer_account_id
-      )
-    end
-
-    def update_entry_params
-      return entry_params unless entry_params[:entryable_attributes].present?
-
-      update_params = entry_params
-      update_params = update_params.merge(entryable_type: "Trade")
-
-      qty = update_params[:entryable_attributes][:qty]
-      price = update_params[:entryable_attributes][:price]
-
-      if qty.present? && price.present?
-        qty = update_params[:nature] == "inflow" ? -qty.to_d : qty.to_d
-        update_params[:entryable_attributes][:qty] = qty
-        update_params[:amount] = qty * price.to_d
-      end
-
-      update_params.except(:nature)
-    end
+    update_params.except(:nature)
+  end
 end

--- a/app/controllers/transaction_categories_controller.rb
+++ b/app/controllers/transaction_categories_controller.rb
@@ -34,19 +34,19 @@ class TransactionCategoriesController < ApplicationController
   end
 
   private
-    def entry_params
-      params.require(:entry).permit(:entryable_type, entryable_attributes: [:id, :category_id])
+  def entry_params
+    params.require(:entry).permit(:entryable_type, entryable_attributes: [:id, :category_id])
+  end
+
+  def needs_rule_notification?(transaction)
+    return false if Current.user.rule_prompts_disabled
+
+    if Current.user.rule_prompt_dismissed_at.present?
+      time_since_last_rule_prompt = Time.current - Current.user.rule_prompt_dismissed_at
+      return false if time_since_last_rule_prompt < 1.day
     end
 
-    def needs_rule_notification?(transaction)
-      return false if Current.user.rule_prompts_disabled
-
-      if Current.user.rule_prompt_dismissed_at.present?
-        time_since_last_rule_prompt = Time.current - Current.user.rule_prompt_dismissed_at
-        return false if time_since_last_rule_prompt < 1.day
-      end
-
-      transaction.saved_change_to_category_id? &&
-      transaction.eligible_for_category_rule?
-    end
+    transaction.saved_change_to_category_id? &&
+    transaction.eligible_for_category_rule?
+  end
 end

--- a/app/controllers/transactions/bulk_deletions_controller.rb
+++ b/app/controllers/transactions/bulk_deletions_controller.rb
@@ -6,7 +6,7 @@ class Transactions::BulkDeletionsController < ApplicationController
   end
 
   private
-    def bulk_delete_params
-      params.require(:bulk_delete).permit(entry_ids: [])
-    end
+  def bulk_delete_params
+    params.require(:bulk_delete).permit(entry_ids: [])
+  end
 end

--- a/app/controllers/transactions/bulk_updates_controller.rb
+++ b/app/controllers/transactions/bulk_updates_controller.rb
@@ -12,8 +12,8 @@ class Transactions::BulkUpdatesController < ApplicationController
   end
 
   private
-    def bulk_update_params
-      params.require(:bulk_update)
-            .permit(:date, :notes, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
-    end
+  def bulk_update_params
+    params.require(:bulk_update)
+          .permit(:date, :notes, :category_id, :merchant_id, entry_ids: [], tag_ids: [])
+  end
 end

--- a/app/controllers/transfer_matches_controller.rb
+++ b/app/controllers/transfer_matches_controller.rb
@@ -20,42 +20,42 @@ class TransferMatchesController < ApplicationController
   end
 
   private
-    def set_entry
-      @entry = Current.family.entries.find(params[:transaction_id])
-    end
+  def set_entry
+    @entry = Current.family.entries.find(params[:transaction_id])
+  end
 
-    def transfer_match_params
-      params.require(:transfer_match).permit(:method, :matched_entry_id, :target_account_id)
-    end
+  def transfer_match_params
+    params.require(:transfer_match).permit(:method, :matched_entry_id, :target_account_id)
+  end
 
-    def build_transfer
-      if transfer_match_params[:method] == "new"
-        target_account = Current.family.accounts.find(transfer_match_params[:target_account_id])
+  def build_transfer
+    if transfer_match_params[:method] == "new"
+      target_account = Current.family.accounts.find(transfer_match_params[:target_account_id])
 
-        missing_transaction = Transaction.new(
-          entry: target_account.entries.build(
-            amount: @entry.amount * -1,
-            currency: @entry.currency,
-            date: @entry.date,
-            name: "Transfer to #{@entry.amount.negative? ? @entry.account.name : target_account.name}",
-          )
+      missing_transaction = Transaction.new(
+        entry: target_account.entries.build(
+          amount: @entry.amount * -1,
+          currency: @entry.currency,
+          date: @entry.date,
+          name: "Transfer to #{@entry.amount.negative? ? @entry.account.name : target_account.name}",
         )
+      )
 
-        transfer = Transfer.find_or_initialize_by(
-          inflow_transaction: @entry.amount.positive? ? missing_transaction : @entry.transaction,
-          outflow_transaction: @entry.amount.positive? ? @entry.transaction : missing_transaction
-        )
-        transfer.status = "confirmed"
-        transfer
-      else
-        target_transaction = Current.family.entries.find(transfer_match_params[:matched_entry_id])
+      transfer = Transfer.find_or_initialize_by(
+        inflow_transaction: @entry.amount.positive? ? missing_transaction : @entry.transaction,
+        outflow_transaction: @entry.amount.positive? ? @entry.transaction : missing_transaction
+      )
+      transfer.status = "confirmed"
+      transfer
+    else
+      target_transaction = Current.family.entries.find(transfer_match_params[:matched_entry_id])
 
-        transfer = Transfer.find_or_initialize_by(
-          inflow_transaction: @entry.amount.negative? ? @entry.transaction : target_transaction.transaction,
-          outflow_transaction: @entry.amount.negative? ? target_transaction.transaction : @entry.transaction
-        )
-        transfer.status = "confirmed"
-        transfer
-      end
+      transfer = Transfer.find_or_initialize_by(
+        inflow_transaction: @entry.amount.negative? ? @entry.transaction : target_transaction.transaction,
+        outflow_transaction: @entry.amount.negative? ? target_transaction.transaction : @entry.transaction
+      )
+      transfer.status = "confirmed"
+      transfer
     end
+  end
 end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -49,32 +49,32 @@ class TransfersController < ApplicationController
   end
 
   private
-    def set_transfer
-      # Finds the transfer and ensures the family owns it
-      @transfer = Transfer
-                    .where(id: params[:id])
-                    .where(inflow_transaction_id: Current.family.transactions.select(:id))
-                    .first
-    end
+  def set_transfer
+    # Finds the transfer and ensures the family owns it
+    @transfer = Transfer
+                  .where(id: params[:id])
+                  .where(inflow_transaction_id: Current.family.transactions.select(:id))
+                  .first
+  end
 
-    def transfer_params
-      params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded)
-    end
+  def transfer_params
+    params.require(:transfer).permit(:from_account_id, :to_account_id, :amount, :date, :name, :excluded)
+  end
 
-    def transfer_update_params
-      params.require(:transfer).permit(:notes, :status, :category_id)
-    end
+  def transfer_update_params
+    params.require(:transfer).permit(:notes, :status, :category_id)
+  end
 
-    def update_transfer_status
-      if transfer_update_params[:status] == "rejected"
-        @transfer.reject!
-      elsif transfer_update_params[:status] == "confirmed"
-        @transfer.confirm!
-      end
+  def update_transfer_status
+    if transfer_update_params[:status] == "rejected"
+      @transfer.reject!
+    elsif transfer_update_params[:status] == "confirmed"
+      @transfer.confirm!
     end
+  end
 
-    def update_transfer_details
-      @transfer.outflow_transaction.update!(category_id: transfer_update_params[:category_id])
-      @transfer.update!(notes: transfer_update_params[:notes])
-    end
+  def update_transfer_details
+    @transfer.outflow_transaction.update!(category_id: transfer_update_params[:category_id])
+    @transfer.update!(notes: transfer_update_params[:notes])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,50 +55,50 @@ class UsersController < ApplicationController
   end
 
   private
-    def handle_redirect(notice)
-      case user_params[:redirect_to]
-      when "onboarding_preferences"
-        redirect_to preferences_onboarding_path
-      when "home"
-        redirect_to root_path
-      when "preferences"
-        redirect_to settings_preferences_path, notice: notice
-      when "goals"
-        redirect_to goals_onboarding_path
-      when "trial"
-        redirect_to trial_onboarding_path
-      else
-        redirect_to settings_profile_path, notice: notice
-      end
+  def handle_redirect(notice)
+    case user_params[:redirect_to]
+    when "onboarding_preferences"
+      redirect_to preferences_onboarding_path
+    when "home"
+      redirect_to root_path
+    when "preferences"
+      redirect_to settings_preferences_path, notice: notice
+    when "goals"
+      redirect_to goals_onboarding_path
+    when "trial"
+      redirect_to trial_onboarding_path
+    else
+      redirect_to settings_profile_path, notice: notice
     end
+  end
 
-    def should_purge_profile_image?
-      user_params[:delete_profile_image] == "1" &&
-        user_params[:profile_image].blank?
-    end
+  def should_purge_profile_image?
+    user_params[:delete_profile_image] == "1" &&
+      user_params[:profile_image].blank?
+  end
 
-    def email_changed?
-      user_params[:email].present? && user_params[:email] != @user.email
-    end
+  def email_changed?
+    user_params[:email].present? && user_params[:email] != @user.email
+  end
 
-    def rule_prompt_settings_params
-      params.require(:user).permit(:rule_prompt_dismissed_at, :rule_prompts_disabled)
-    end
+  def rule_prompt_settings_params
+    params.require(:user).permit(:rule_prompt_dismissed_at, :rule_prompts_disabled)
+  end
 
-    def user_params
-      params.require(:user).permit(
-        :first_name, :last_name, :email, :profile_image, :redirect_to, :delete_profile_image, :onboarded_at,
-        :show_sidebar, :default_period, :show_ai_sidebar, :ai_enabled, :theme, :set_onboarding_preferences_at, :set_onboarding_goals_at,
-        family_attributes: [:name, :currency, :country, :locale, :date_format, :timezone, :id],
-        goals: []
-      )
-    end
+  def user_params
+    params.require(:user).permit(
+      :first_name, :last_name, :email, :profile_image, :redirect_to, :delete_profile_image, :onboarded_at,
+      :show_sidebar, :default_period, :show_ai_sidebar, :ai_enabled, :theme, :set_onboarding_preferences_at, :set_onboarding_goals_at,
+      family_attributes: [:name, :currency, :country, :locale, :date_format, :timezone, :id],
+      goals: []
+    )
+  end
 
-    def set_user
-      @user = Current.user
-    end
+  def set_user
+    @user = Current.user
+  end
 
-    def ensure_admin
-      redirect_to settings_profile_path, alert: I18n.t("users.reset.unauthorized") unless Current.user.admin?
-    end
+  def ensure_admin
+    redirect_to settings_profile_path, alert: I18n.t("users.reset.unauthorized") unless Current.user.admin?
+  end
 end

--- a/app/controllers/valuations_controller.rb
+++ b/app/controllers/valuations_controller.rb
@@ -83,7 +83,7 @@ class ValuationsController < ApplicationController
   end
 
   private
-    def entry_params
-      params.require(:entry).permit(:date, :amount, :notes)
-    end
+  def entry_params
+    params.require(:entry).permit(:date, :amount, :notes)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,15 +109,15 @@ module ApplicationHelper
   end
 
   private
-    def calculate_total(item, money_method, negate)
-      # Filter out transfer-type transactions from entries
-      # Only Entry objects have entryable transactions, Account objects don't
-      items = item.reject do |i|
-        i.is_a?(Entry) &&
-        i.entryable.is_a?(Transaction) &&
-        i.entryable.transfer?
-      end
-      total = items.sum(&money_method)
-      negate ? -total : total
+  def calculate_total(item, money_method, negate)
+    # Filter out transfer-type transactions from entries
+    # Only Entry objects have entryable transactions, Account objects don't
+    items = item.reject do |i|
+      i.is_a?(Entry) &&
+      i.entryable.is_a?(Transaction) &&
+      i.entryable.transfer?
     end
+    total = items.sum(&money_method)
+    negate ? -total : total
+  end
 end

--- a/app/helpers/custom_confirm.rb
+++ b/app/helpers/custom_confirm.rb
@@ -30,22 +30,22 @@ class CustomConfirm
   end
 
   private
-    attr_reader :title, :body, :btn_text, :btn_variant
+  attr_reader :title, :body, :btn_text, :btn_variant
 
-    def derive_btn_variant(destructive, high_severity)
-      return "primary" unless destructive
-      high_severity ? "destructive" : "outline-destructive"
-    end
+  def derive_btn_variant(destructive, high_severity)
+    return "primary" unless destructive
+    high_severity ? "destructive" : "outline-destructive"
+  end
 
-    def default_title
-      "Are you sure?"
-    end
+  def default_title
+    "Are you sure?"
+  end
 
-    def default_body
-      "This is not reversible."
-    end
+  def default_body
+    "This is not reversible."
+  end
 
-    def default_btn_text
-      "Confirm"
-    end
+  def default_btn_text
+    "Confirm"
+  end
 end

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -61,9 +61,9 @@ module ImportsHelper
   end
 
   private
-    def permitted_import_types
-      %w[transaction_import trade_import account_import mint_import]
-    end
+  def permitted_import_types
+    %w[transaction_import trade_import account_import mint_import]
+  end
 
-    DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)
+  DryRunResource = Struct.new(:label, :icon, :text_class, :bg_class, keyword_init: true)
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -59,7 +59,7 @@ module SettingsHelper
   end
 
   private
-    def not_self_hosted?
-      !self_hosted?
-    end
+  def not_self_hosted?
+    !self_hosted?
+  end
 end

--- a/app/helpers/styled_form_builder.rb
+++ b/app/helpers/styled_form_builder.rb
@@ -76,63 +76,63 @@ class StyledFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   private
-    def build_field(method, options = {}, html_options = {}, &block)
-      if options[:inline] || options[:label] == false
-        return yield({ class: "form-field__input" }.merge(html_options))
-      end
+  def build_field(method, options = {}, html_options = {}, &block)
+    if options[:inline] || options[:label] == false
+      return yield({ class: "form-field__input" }.merge(html_options))
+    end
 
-      label_element = build_label(method, options)
-      field_element = yield({ class: "form-field__input" }.merge(html_options))
+    label_element = build_label(method, options)
+    field_element = yield({ class: "form-field__input" }.merge(html_options))
 
-      container_classes = ["form-field", options[:container_class]].compact
+    container_classes = ["form-field", options[:container_class]].compact
 
-      @template.tag.div class: container_classes do
-        if options[:label_tooltip]
-          @template.tag.div(class: "form-field__header") do
-            label_element +
-            @template.tag.div(class: "form-field__actions") do
-              build_tooltip(options[:label_tooltip])
-            end
-          end +
-          @template.tag.div(class: "form-field__body") do
-            field_element
+    @template.tag.div class: container_classes do
+      if options[:label_tooltip]
+        @template.tag.div(class: "form-field__header") do
+          label_element +
+          @template.tag.div(class: "form-field__actions") do
+            build_tooltip(options[:label_tooltip])
           end
-        else
-          @template.tag.div(class: "form-field__body") do
-            label_element + field_element
-          end
+        end +
+        @template.tag.div(class: "form-field__body") do
+          field_element
+        end
+      else
+        @template.tag.div(class: "form-field__body") do
+          label_element + field_element
         end
       end
     end
+  end
 
-    def normalize_options(options, html_options)
-      options.merge(required: options[:required] || html_options[:required])
+  def normalize_options(options, html_options)
+    options.merge(required: options[:required] || html_options[:required])
+  end
+
+  def build_label(method, options)
+    return "".html_safe unless options[:label]
+
+    label_text = options[:label]
+
+    if options[:required]
+      label_text = @template.safe_join([
+        label_text == true ? method.to_s.humanize : label_text,
+        @template.tag.span("*", class: "text-red-500 ml-0.5")
+      ])
     end
 
-    def build_label(method, options)
-      return "".html_safe unless options[:label]
+    return label(method, class: "form-field__label") if label_text == true
+    label(method, label_text, class: "form-field__label")
+  end
 
-      label_text = options[:label]
+  def build_tooltip(tooltip_text)
+    return nil unless tooltip_text
 
-      if options[:required]
-        label_text = @template.safe_join([
-          label_text == true ? method.to_s.humanize : label_text,
-          @template.tag.span("*", class: "text-red-500 ml-0.5")
-        ])
-      end
-
-      return label(method, class: "form-field__label") if label_text == true
-      label(method, label_text, class: "form-field__label")
+    @template.tag.div(data: { controller: "tooltip" }) do
+      @template.safe_join([
+        @template.icon("help-circle", size: "sm", color: "default", class: "cursor-help"),
+        @template.tag.div(tooltip_text, role: "tooltip", data: { tooltip_target: "tooltip" }, class: "tooltip bg-gray-700 text-sm p-2 rounded w-64 text-white")
+      ])
     end
-
-    def build_tooltip(tooltip_text)
-      return nil unless tooltip_text
-
-      @template.tag.div(data: { controller: "tooltip" }) do
-        @template.safe_join([
-          @template.icon("help-circle", size: "sm", color: "default", class: "cursor-help"),
-          @template.tag.div(tooltip_text, role: "tooltip", data: { tooltip_target: "tooltip" }, class: "tooltip bg-gray-700 text-sm p-2 rounded w-64 text-white")
-        ])
-      end
-    end
+  end
 end

--- a/app/models/account/anchorable.rb
+++ b/app/models/account/anchorable.rb
@@ -46,11 +46,11 @@ module Account::Anchorable
   end
 
   private
-    def opening_balance_manager
-      @opening_balance_manager ||= Account::OpeningBalanceManager.new(self)
-    end
+  def opening_balance_manager
+    @opening_balance_manager ||= Account::OpeningBalanceManager.new(self)
+  end
 
-    def current_balance_manager
-      @current_balance_manager ||= Account::CurrentBalanceManager.new(self)
-    end
+  def current_balance_manager
+    @current_balance_manager ||= Account::CurrentBalanceManager.new(self)
+  end
 end

--- a/app/models/account/current_balance_manager.rb
+++ b/app/models/account/current_balance_manager.rb
@@ -46,96 +46,96 @@ class Account::CurrentBalanceManager
   end
 
   private
-    attr_reader :account
+  attr_reader :account
 
-    def opening_balance_manager
-      @opening_balance_manager ||= Account::OpeningBalanceManager.new(account)
-    end
+  def opening_balance_manager
+    @opening_balance_manager ||= Account::OpeningBalanceManager.new(account)
+  end
 
-    def reconciliation_manager
-      @reconciliation_manager ||= Account::ReconciliationManager.new(account)
-    end
+  def reconciliation_manager
+    @reconciliation_manager ||= Account::ReconciliationManager.new(account)
+  end
 
-    # Manual accounts do not manage the `current_anchor` valuation (otherwise, user would need to continually update it, which is bad UX)
-    # Instead, we use a combination of "auto-update strategies" to set the current balance according to the user's intent.
-    #
-    # The "auto-update strategies" are:
-    # 1. Value tracking - If the account has a reconciliation already, we assume they are tracking the account value primarily with reconciliations, so we append a new one
-    # 2. Transaction adjustment - If the account doesn't have recons, we assume user is tracking with transactions, so we adjust the opening balance with a delta until it
-    #                             gets us to the desired balance. This ensures we don't append unnecessary reconciliations to the account, which "reset" the value from that
-    #                             date forward (not user's intent).
-    #
-    # For more documentation on these auto-update strategies, see the test cases.
-    def set_current_balance_for_manual_account(balance)
-      # If we're dealing with a cash account that has no reconciliations, use "Transaction adjustment" strategy (update opening balance to "back in" to the desired current balance)
-      if account.balance_type == :cash && account.valuations.reconciliation.empty?
-        adjust_opening_balance_with_delta(new_balance: balance, old_balance: account.balance)
-      else
-        existing_reconciliation = account.entries.valuations.find_by(date: Date.current)
+  # Manual accounts do not manage the `current_anchor` valuation (otherwise, user would need to continually update it, which is bad UX)
+  # Instead, we use a combination of "auto-update strategies" to set the current balance according to the user's intent.
+  #
+  # The "auto-update strategies" are:
+  # 1. Value tracking - If the account has a reconciliation already, we assume they are tracking the account value primarily with reconciliations, so we append a new one
+  # 2. Transaction adjustment - If the account doesn't have recons, we assume user is tracking with transactions, so we adjust the opening balance with a delta until it
+  #                             gets us to the desired balance. This ensures we don't append unnecessary reconciliations to the account, which "reset" the value from that
+  #                             date forward (not user's intent).
+  #
+  # For more documentation on these auto-update strategies, see the test cases.
+  def set_current_balance_for_manual_account(balance)
+    # If we're dealing with a cash account that has no reconciliations, use "Transaction adjustment" strategy (update opening balance to "back in" to the desired current balance)
+    if account.balance_type == :cash && account.valuations.reconciliation.empty?
+      adjust_opening_balance_with_delta(new_balance: balance, old_balance: account.balance)
+    else
+      existing_reconciliation = account.entries.valuations.find_by(date: Date.current)
 
-        result = reconciliation_manager.reconcile_balance(balance: balance, date: Date.current, existing_valuation_entry: existing_reconciliation)
-
-        # Normalize to expected result format
-        Result.new(success?: result.success?, changes_made?: true, error: result.error_message)
-      end
-    end
-
-    def adjust_opening_balance_with_delta(new_balance:, old_balance:)
-      delta = new_balance - old_balance
-
-      result = opening_balance_manager.set_opening_balance(balance: account.opening_anchor_balance + delta)
+      result = reconciliation_manager.reconcile_balance(balance: balance, date: Date.current, existing_valuation_entry: existing_reconciliation)
 
       # Normalize to expected result format
-      Result.new(success?: result.success?, changes_made?: true, error: result.error)
+      Result.new(success?: result.success?, changes_made?: true, error: result.error_message)
     end
+  end
 
-    # Linked accounts manage "current balance" via the special `current_anchor` valuation.
-    # This is NOT a user-facing feature, and is primarily used in "processors" while syncing
-    # linked account data (e.g. via Plaid)
-    def set_current_balance_for_linked_account(balance)
-      if current_anchor_valuation
-        changes_made = update_current_anchor(balance)
-        Result.new(success?: true, changes_made?: changes_made, error: nil)
-      else
-        create_current_anchor(balance)
-        Result.new(success?: true, changes_made?: true, error: nil)
+  def adjust_opening_balance_with_delta(new_balance:, old_balance:)
+    delta = new_balance - old_balance
+
+    result = opening_balance_manager.set_opening_balance(balance: account.opening_anchor_balance + delta)
+
+    # Normalize to expected result format
+    Result.new(success?: result.success?, changes_made?: true, error: result.error)
+  end
+
+  # Linked accounts manage "current balance" via the special `current_anchor` valuation.
+  # This is NOT a user-facing feature, and is primarily used in "processors" while syncing
+  # linked account data (e.g. via Plaid)
+  def set_current_balance_for_linked_account(balance)
+    if current_anchor_valuation
+      changes_made = update_current_anchor(balance)
+      Result.new(success?: true, changes_made?: changes_made, error: nil)
+    else
+      create_current_anchor(balance)
+      Result.new(success?: true, changes_made?: true, error: nil)
+    end
+  end
+
+  def current_anchor_valuation
+    @current_anchor_valuation ||= account.valuations.current_anchor.includes(:entry).first
+  end
+
+  def create_current_anchor(balance)
+    account.entries.create!(
+      date: Date.current,
+      name: Valuation.build_current_anchor_name(account.accountable_type),
+      amount: balance,
+      currency: account.currency,
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+  end
+
+  def update_current_anchor(balance)
+    changes_made = false
+
+    ActiveRecord::Base.transaction do
+      # Update associated entry attributes
+      entry = current_anchor_valuation.entry
+
+      if entry.amount != balance
+        entry.amount = balance
+        changes_made = true
       end
-    end
 
-    def current_anchor_valuation
-      @current_anchor_valuation ||= account.valuations.current_anchor.includes(:entry).first
-    end
-
-    def create_current_anchor(balance)
-      account.entries.create!(
-        date: Date.current,
-        name: Valuation.build_current_anchor_name(account.accountable_type),
-        amount: balance,
-        currency: account.currency,
-        entryable: Valuation.new(kind: "current_anchor")
-      )
-    end
-
-    def update_current_anchor(balance)
-      changes_made = false
-
-      ActiveRecord::Base.transaction do
-        # Update associated entry attributes
-        entry = current_anchor_valuation.entry
-
-        if entry.amount != balance
-          entry.amount = balance
-          changes_made = true
-        end
-
-        if entry.date != Date.current
-          entry.date = Date.current
-          changes_made = true
-        end
-
-        entry.save! if entry.changed?
+      if entry.date != Date.current
+        entry.date = Date.current
+        changes_made = true
       end
 
-      changes_made
+      entry.save! if entry.changed?
     end
+
+    changes_made
+  end
 end

--- a/app/models/account/market_data_importer.rb
+++ b/app/models/account/market_data_importer.rb
@@ -60,23 +60,23 @@ class Account::MarketDataImporter
   end
 
   private
-    # Calculates the first date we require a price for the given security scoped to this account
-    def first_required_price_date(security)
-      account.trades.with_entry
-                    .where(security: security)
-                    .where(entries: { account_id: account.id })
-                    .minimum("entries.date")
-    end
+  # Calculates the first date we require a price for the given security scoped to this account
+  def first_required_price_date(security)
+    account.trades.with_entry
+                  .where(security: security)
+                  .where(entries: { account_id: account.id })
+                  .minimum("entries.date")
+  end
 
-    def needs_exchange_rates?
-      has_multi_currency_entries? || foreign_account?
-    end
+  def needs_exchange_rates?
+    has_multi_currency_entries? || foreign_account?
+  end
 
-    def has_multi_currency_entries?
-      account.entries.where.not(currency: account.currency).exists?
-    end
+  def has_multi_currency_entries?
+    account.entries.where.not(currency: account.currency).exists?
+  end
 
-    def foreign_account?
-      account.currency != account.family.currency
-    end
+  def foreign_account?
+    account.currency != account.family.currency
+  end
 end

--- a/app/models/account/reconcileable.rb
+++ b/app/models/account/reconcileable.rb
@@ -14,7 +14,7 @@ module Account::Reconcileable
   end
 
   private
-    def reconciliation_manager
-      @reconciliation_manager ||= Account::ReconciliationManager.new(self)
-    end
+  def reconciliation_manager
+    @reconciliation_manager ||= Account::ReconciliationManager.new(self)
+  end
 end

--- a/app/models/account/sync_complete_event.rb
+++ b/app/models/account/sync_complete_event.rb
@@ -37,27 +37,27 @@ class Account::SyncCompleteEvent
   end
 
   private
-    # Returns an array of [tab, mobile?] tuples that should receive an update.
-    # We broadcast to both the classification-specific tab and the "all" tab,
-    # for desktop (mobile: false) and mobile (mobile: true) variants.
-    def sidebar_targets
-      return [] unless account_group.present?
+  # Returns an array of [tab, mobile?] tuples that should receive an update.
+  # We broadcast to both the classification-specific tab and the "all" tab,
+  # for desktop (mobile: false) and mobile (mobile: true) variants.
+  def sidebar_targets
+    return [] unless account_group.present?
 
-      [
-        [account_group.classification.to_sym, false],
-        [:all, false],
-        [account_group.classification.to_sym, true],
-        [:all, true]
-      ]
-    end
+    [
+      [account_group.classification.to_sym, false],
+      [:all, false],
+      [account_group.classification.to_sym, true],
+      [:all, true]
+    ]
+  end
 
-    def account_group
-      family_balance_sheet.account_groups.find do |group|
-        group.accounts.any? { |a| a.id == account.id }
-      end
+  def account_group
+    family_balance_sheet.account_groups.find do |group|
+      group.accounts.any? { |a| a.id == account.id }
     end
+  end
 
-    def family_balance_sheet
-      account.family.balance_sheet
-    end
+  def family_balance_sheet
+    account.family.balance_sheet
+  end
 end

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -16,22 +16,22 @@ class Account::Syncer
   end
 
   private
-    def materialize_balances
-      strategy = account.linked? ? :reverse : :forward
-      Balance::Materializer.new(account, strategy: strategy).materialize_balances
-    end
+  def materialize_balances
+    strategy = account.linked? ? :reverse : :forward
+    Balance::Materializer.new(account, strategy: strategy).materialize_balances
+  end
 
-    # Syncs all the exchange rates + security prices this account needs to display historical chart data
-    #
-    # This is a *supplemental* sync.  The daily market data sync should have already populated
-    # a majority or all of this data, so this is often a no-op.
-    #
-    # We rescue errors here because if this operation fails, we don't want to fail the entire sync since
-    # we have reasonable fallbacks for missing market data.
-    def import_market_data
-      Account::MarketDataImporter.new(account).import_all
-    rescue => e
-      Rails.logger.error("Error syncing market data for account #{account.id}: #{e.message}")
-      Sentry.capture_exception(e)
-    end
+  # Syncs all the exchange rates + security prices this account needs to display historical chart data
+  #
+  # This is a *supplemental* sync.  The daily market data sync should have already populated
+  # a majority or all of this data, so this is often a no-op.
+  #
+  # We rescue errors here because if this operation fails, we don't want to fail the entire sync since
+  # we have reasonable fallbacks for missing market data.
+  def import_market_data
+    Account::MarketDataImporter.new(account).import_all
+  rescue => e
+    Rails.logger.error("Error syncing market data for account #{account.id}: #{e.message}")
+    Sentry.capture_exception(e)
+  end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -70,25 +70,25 @@ class ApiKey < ApplicationRecord
 
   private
 
-    def set_display_key
-      if key.present?
-        self.display_key = key
-      end
+  def set_display_key
+    if key.present?
+      self.display_key = key
     end
+  end
 
-    def scopes_not_empty
-      if scopes.blank? || (scopes.is_a?(Array) && (scopes.empty? || scopes.all?(&:blank?)))
-        errors.add(:scopes, "must include at least one permission")
-      elsif scopes.is_a?(Array) && scopes.length > 1
-        errors.add(:scopes, "can only have one permission level")
-      elsif scopes.is_a?(Array) && !%w[read read_write].include?(scopes.first)
-        errors.add(:scopes, "must be either 'read' or 'read_write'")
-      end
+  def scopes_not_empty
+    if scopes.blank? || (scopes.is_a?(Array) && (scopes.empty? || scopes.all?(&:blank?)))
+      errors.add(:scopes, "must include at least one permission")
+    elsif scopes.is_a?(Array) && scopes.length > 1
+      errors.add(:scopes, "can only have one permission level")
+    elsif scopes.is_a?(Array) && !%w[read read_write].include?(scopes.first)
+      errors.add(:scopes, "must be either 'read' or 'read_write'")
     end
+  end
 
-    def one_active_key_per_user_per_source
-      if user&.api_keys&.active&.where(source: source)&.where&.not(id: id)&.exists?
-        errors.add(:user, "can only have one active API key per source (#{source})")
-      end
+  def one_active_key_per_user_per_source
+    if user&.api_keys&.active&.where(source: source)&.where&.not(id: id)&.exists?
+      errors.add(:user, "can only have one active API key per source (#{source})")
     end
+  end
 end

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -63,13 +63,13 @@ class Assistant
   end
 
   private
-    attr_reader :functions
+  attr_reader :functions
 
-    def function_tool_caller
-      function_instances = functions.map do |fn|
-        fn.new(chat.user)
-      end
-
-      @function_tool_caller ||= FunctionToolCaller.new(function_instances)
+  def function_tool_caller
+    function_instances = functions.map do |fn|
+      fn.new(chat.user)
     end
+
+    @function_tool_caller ||= FunctionToolCaller.new(function_instances)
+  end
 end

--- a/app/models/assistant/broadcastable.rb
+++ b/app/models/assistant/broadcastable.rb
@@ -2,11 +2,11 @@ module Assistant::Broadcastable
   extend ActiveSupport::Concern
 
   private
-    def update_thinking(thought)
-      chat.broadcast_update target: "thinking-indicator", partial: "chats/thinking_indicator", locals: { chat: chat, message: thought }
-    end
+  def update_thinking(thought)
+    chat.broadcast_update target: "thinking-indicator", partial: "chats/thinking_indicator", locals: { chat: chat, message: thought }
+  end
 
-    def stop_thinking
-      chat.broadcast_remove target: "thinking-indicator"
-    end
+  def stop_thinking
+    chat.broadcast_remove target: "thinking-indicator"
+  end
 end

--- a/app/models/assistant/configurable.rb
+++ b/app/models/assistant/configurable.rb
@@ -13,17 +13,17 @@ module Assistant::Configurable
     end
 
     private
-      def default_functions
-        [
-          Assistant::Function::GetTransactions,
-          Assistant::Function::GetAccounts,
-          Assistant::Function::GetBalanceSheet,
-          Assistant::Function::GetIncomeStatement
-        ]
-      end
+    def default_functions
+      [
+        Assistant::Function::GetTransactions,
+        Assistant::Function::GetAccounts,
+        Assistant::Function::GetBalanceSheet,
+        Assistant::Function::GetIncomeStatement
+      ]
+    end
 
-      def default_instructions(preferred_currency, preferred_date_format)
-        <<~PROMPT
+    def default_instructions(preferred_currency, preferred_date_format)
+      <<~PROMPT
           ## Your identity
 
           You are a friendly financial assistant for an open source personal finance application called "Maybe", which is short for "Maybe Finance".
@@ -77,6 +77,6 @@ module Assistant::Configurable
           - If you suspect that you do not have enough data to 100% accurately answer, be transparent about it and state exactly what
             the data you're presenting represents and what context it is in (i.e. date range, account, etc.)
         PROMPT
-      end
+    end
   end
 end

--- a/app/models/assistant/function.rb
+++ b/app/models/assistant/function.rb
@@ -44,49 +44,49 @@ class Assistant::Function
   end
 
   private
-    attr_reader :user
+  attr_reader :user
 
-    def build_schema(properties: {}, required: [])
-      {
-        type: "object",
-        properties: properties,
-        required: required,
-        additionalProperties: false
-      }
-    end
+  def build_schema(properties: {}, required: [])
+    {
+      type: "object",
+      properties: properties,
+      required: required,
+      additionalProperties: false
+    }
+  end
 
-    def family_account_names
-      @family_account_names ||= family.accounts.visible.pluck(:name)
-    end
+  def family_account_names
+    @family_account_names ||= family.accounts.visible.pluck(:name)
+  end
 
-    def family_category_names
-      @family_category_names ||= begin
-        names = family.categories.pluck(:name)
-        names << "Uncategorized"
-        names
-      end
+  def family_category_names
+    @family_category_names ||= begin
+      names = family.categories.pluck(:name)
+      names << "Uncategorized"
+      names
     end
+  end
 
-    def family_merchant_names
-      @family_merchant_names ||= family.merchants.pluck(:name)
-    end
+  def family_merchant_names
+    @family_merchant_names ||= family.merchants.pluck(:name)
+  end
 
-    def family_tag_names
-      @family_tag_names ||= family.tags.pluck(:name)
-    end
+  def family_tag_names
+    @family_tag_names ||= family.tags.pluck(:name)
+  end
 
-    def family
-      user.family
-    end
+  def family
+    user.family
+  end
 
-    # To save tokens, we provide the AI metadata about the series and a flat array of
-    # raw, formatted values which it can infer dates from
-    def to_ai_time_series(series)
-      {
-        start_date: series.start_date,
-        end_date: series.end_date,
-        interval: series.interval,
-        values: series.values.map { |v| v.trend.current.format }
-      }
-    end
+  # To save tokens, we provide the AI metadata about the series and a flat array of
+  # raw, formatted values which it can infer dates from
+  def to_ai_time_series(series)
+    {
+      start_date: series.start_date,
+      end_date: series.end_date,
+      interval: series.interval,
+      values: series.values.map { |v| v.trend.current.format }
+    }
+  end
 end

--- a/app/models/assistant/function/get_accounts.rb
+++ b/app/models/assistant/function/get_accounts.rb
@@ -30,11 +30,11 @@ class Assistant::Function::GetAccounts < Assistant::Function
   end
 
   private
-    def historical_balances(account)
-      start_date = [account.start_date, 5.years.ago.to_date].max
-      period = Period.custom(start_date: start_date, end_date: Date.current)
-      balance_series = account.balance_series(period: period, interval: "1 month")
+  def historical_balances(account)
+    start_date = [account.start_date, 5.years.ago.to_date].max
+    period = Period.custom(start_date: start_date, end_date: Date.current)
+    balance_series = account.balance_series(period: period, interval: "1 month")
 
-      to_ai_time_series(balance_series)
-    end
+    to_ai_time_series(balance_series)
+  end
 end

--- a/app/models/assistant/function/get_balance_sheet.rb
+++ b/app/models/assistant/function/get_balance_sheet.rb
@@ -43,34 +43,34 @@ class Assistant::Function::GetBalanceSheet < Assistant::Function
   end
 
   private
-    def historical_data(period, classification: nil)
-      scope = family.accounts.visible
-      scope = scope.where(classification: classification) if classification.present?
+  def historical_data(period, classification: nil)
+    scope = family.accounts.visible
+    scope = scope.where(classification: classification) if classification.present?
 
-      if period.start_date == Date.current
-        []
-      else
-        account_ids = scope.pluck(:id)
+    if period.start_date == Date.current
+      []
+    else
+      account_ids = scope.pluck(:id)
 
-        builder = Balance::ChartSeriesBuilder.new(
-          account_ids: account_ids,
-          currency: family.currency,
-          period: period,
-          favorable_direction: "up",
-          interval: "1 month"
-        )
+      builder = Balance::ChartSeriesBuilder.new(
+        account_ids: account_ids,
+        currency: family.currency,
+        period: period,
+        favorable_direction: "up",
+        interval: "1 month"
+      )
 
-        to_ai_time_series(builder.balance_series)
-      end
+      to_ai_time_series(builder.balance_series)
     end
+  end
 
-    def insights_data
-      assets = family.balance_sheet.assets.total
-      liabilities = family.balance_sheet.liabilities.total
-      ratio = liabilities.zero? ? 0 : (liabilities / assets.to_f)
+  def insights_data
+    assets = family.balance_sheet.assets.total
+    liabilities = family.balance_sheet.liabilities.total
+    ratio = liabilities.zero? ? 0 : (liabilities / assets.to_f)
 
-      {
-        debt_to_asset_ratio: number_to_percentage(ratio * 100, precision: 0)
-      }
-    end
+    {
+      debt_to_asset_ratio: number_to_percentage(ratio * 100, precision: 0)
+    }
+  end
 end

--- a/app/models/assistant/function/get_income_statement.rb
+++ b/app/models/assistant/function/get_income_statement.rb
@@ -67,59 +67,59 @@ class Assistant::Function::GetIncomeStatement < Assistant::Function
   end
 
   private
-    def format_money(value)
-      Money.new(value, family.currency).format
-    end
+  def format_money(value)
+    Money.new(value, family.currency).format
+  end
 
-    def calculate_savings_rate(total_income, total_expenses)
-      return 0 if total_income.zero?
-      savings = total_income - total_expenses
-      rate = (savings / total_income.to_f) * 100
-      rate.round(2)
-    end
+  def calculate_savings_rate(total_income, total_expenses)
+    return 0 if total_income.zero?
+    savings = total_income - total_expenses
+    rate = (savings / total_income.to_f) * 100
+    rate.round(2)
+  end
 
-    def to_ai_category_totals(category_totals)
-      hierarchical_groups = category_totals.group_by { |ct| ct.category.parent_id }.then do |grouped|
-        root_category_totals = grouped[nil] || []
+  def to_ai_category_totals(category_totals)
+    hierarchical_groups = category_totals.group_by { |ct| ct.category.parent_id }.then do |grouped|
+      root_category_totals = grouped[nil] || []
 
-        root_category_totals.each_with_object({}) do |ct, hash|
-          subcategory_totals = ct.category.name == "Uncategorized" ? [] : (grouped[ct.category.id] || [])
-          hash[ct.category.name] = {
-            category_total: ct,
-            subcategory_totals: subcategory_totals
-          }
-        end
-      end
-
-      hierarchical_groups.sort_by { |name, data| -data.dig(:category_total).total }.map do |name, data|
-        {
-          name: name,
-          total: format_money(data.dig(:category_total).total),
-          percentage_of_total: number_to_percentage(data.dig(:category_total).weight, precision: 1),
-          subcategory_totals: data.dig(:subcategory_totals).map do |st|
-            {
-              name: st.category.name,
-              total: format_money(st.total),
-              percentage_of_total: number_to_percentage(st.weight, precision: 1)
-            }
-          end
+      root_category_totals.each_with_object({}) do |ct, hash|
+        subcategory_totals = ct.category.name == "Uncategorized" ? [] : (grouped[ct.category.id] || [])
+        hash[ct.category.name] = {
+          category_total: ct,
+          subcategory_totals: subcategory_totals
         }
       end
     end
 
-    def get_insights(income_data, expense_data)
-      net_income = income_data.total - expense_data.total
-      savings_rate = calculate_savings_rate(income_data.total, expense_data.total)
-      median_monthly_income = family.income_statement.median_income
-      median_monthly_expenses = family.income_statement.median_expense
-      avg_monthly_expenses = family.income_statement.avg_expense
-
+    hierarchical_groups.sort_by { |name, data| -data.dig(:category_total).total }.map do |name, data|
       {
-        net_income: format_money(net_income),
-        savings_rate: number_to_percentage(savings_rate),
-        median_monthly_income: format_money(median_monthly_income),
-        median_monthly_expenses: format_money(median_monthly_expenses),
-        avg_monthly_expenses: format_money(avg_monthly_expenses)
+        name: name,
+        total: format_money(data.dig(:category_total).total),
+        percentage_of_total: number_to_percentage(data.dig(:category_total).weight, precision: 1),
+        subcategory_totals: data.dig(:subcategory_totals).map do |st|
+          {
+            name: st.category.name,
+            total: format_money(st.total),
+            percentage_of_total: number_to_percentage(st.weight, precision: 1)
+          }
+        end
       }
     end
+  end
+
+  def get_insights(income_data, expense_data)
+    net_income = income_data.total - expense_data.total
+    savings_rate = calculate_savings_rate(income_data.total, expense_data.total)
+    median_monthly_income = family.income_statement.median_income
+    median_monthly_expenses = family.income_statement.median_expense
+    avg_monthly_expenses = family.income_statement.avg_expense
+
+    {
+      net_income: format_money(net_income),
+      savings_rate: number_to_percentage(savings_rate),
+      median_monthly_income: format_money(median_monthly_income),
+      median_monthly_expenses: format_money(median_monthly_expenses),
+      avg_monthly_expenses: format_money(avg_monthly_expenses)
+    }
+  end
 end

--- a/app/models/assistant/function/get_transactions.rb
+++ b/app/models/assistant/function/get_transactions.rb
@@ -180,7 +180,7 @@ class Assistant::Function::GetTransactions < Assistant::Function
   end
 
   private
-    def default_page_size
-      self.class.default_page_size
-    end
+  def default_page_size
+    self.class.default_page_size
+  end
 end

--- a/app/models/assistant/function_tool_caller.rb
+++ b/app/models/assistant/function_tool_caller.rb
@@ -21,17 +21,17 @@ class Assistant::FunctionToolCaller
   end
 
   private
-    def execute(function_request)
-      fn = find_function(function_request)
-      fn_args = JSON.parse(function_request.function_args)
-      fn.call(fn_args)
-    rescue => e
-      raise FunctionExecutionError.new(
-        "Error calling function #{fn.name} with arguments #{fn_args}: #{e.message}"
-      )
-    end
+  def execute(function_request)
+    fn = find_function(function_request)
+    fn_args = JSON.parse(function_request.function_args)
+    fn.call(fn_args)
+  rescue => e
+    raise FunctionExecutionError.new(
+      "Error calling function #{fn.name} with arguments #{fn_args}: #{e.message}"
+    )
+  end
 
-    def find_function(function_request)
-      functions.find { |f| f.name == function_request.function_name }
-    end
+  def find_function(function_request)
+    functions.find { |f| f.name == function_request.function_name }
+  end
 end

--- a/app/models/assistant/provided.rb
+++ b/app/models/assistant/provided.rb
@@ -6,7 +6,7 @@ module Assistant::Provided
   end
 
   private
-    def registry
-      @registry ||= Provider::Registry.for_concept(:llm)
-    end
+  def registry
+    @registry ||= Provider::Registry.for_concept(:llm)
+  end
 end

--- a/app/models/assistant/responder.rb
+++ b/app/models/assistant/responder.rb
@@ -31,57 +31,57 @@ class Assistant::Responder
   end
 
   private
-    attr_reader :message, :instructions, :function_tool_caller, :llm
+  attr_reader :message, :instructions, :function_tool_caller, :llm
 
-    def handle_follow_up_response(response)
-      streamer = proc do |chunk|
-        case chunk.type
-        when "output_text"
-          emit(:output_text, chunk.data)
-        when "response"
-          # We do not currently support function executions for a follow-up response (avoid recursive LLM calls that could lead to high spend)
-          emit(:response, { id: chunk.data.id })
-        end
+  def handle_follow_up_response(response)
+    streamer = proc do |chunk|
+      case chunk.type
+      when "output_text"
+        emit(:output_text, chunk.data)
+      when "response"
+        # We do not currently support function executions for a follow-up response (avoid recursive LLM calls that could lead to high spend)
+        emit(:response, { id: chunk.data.id })
       end
-
-      function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
-
-      emit(:response, {
-        id: response.id,
-        function_tool_calls: function_tool_calls
-      })
-
-      # Get follow-up response with tool call results
-      get_llm_response(
-        streamer: streamer,
-        function_results: function_tool_calls.map(&:to_result),
-        previous_response_id: response.id
-      )
     end
 
-    def get_llm_response(streamer:, function_results: [], previous_response_id: nil)
-      response = llm.chat_response(
-        message.content,
-        model: message.ai_model,
-        instructions: instructions,
-        functions: function_tool_caller.function_definitions,
-        function_results: function_results,
-        streamer: streamer,
-        previous_response_id: previous_response_id
-      )
+    function_tool_calls = function_tool_caller.fulfill_requests(response.function_requests)
 
-      unless response.success?
-        raise response.error
-      end
+    emit(:response, {
+      id: response.id,
+      function_tool_calls: function_tool_calls
+    })
 
-      response.data
+    # Get follow-up response with tool call results
+    get_llm_response(
+      streamer: streamer,
+      function_results: function_tool_calls.map(&:to_result),
+      previous_response_id: response.id
+    )
+  end
+
+  def get_llm_response(streamer:, function_results: [], previous_response_id: nil)
+    response = llm.chat_response(
+      message.content,
+      model: message.ai_model,
+      instructions: instructions,
+      functions: function_tool_caller.function_definitions,
+      function_results: function_results,
+      streamer: streamer,
+      previous_response_id: previous_response_id
+    )
+
+    unless response.success?
+      raise response.error
     end
 
-    def emit(event_name, payload = nil)
-      listeners[event_name.to_sym].each { |block| block.call(payload) }
-    end
+    response.data
+  end
 
-    def listeners
-      @listeners ||= Hash.new { |h, k| h[k] = [] }
-    end
+  def emit(event_name, payload = nil)
+    listeners[event_name.to_sym].each { |block| block.call(payload) }
+  end
+
+  def listeners
+    @listeners ||= Hash.new { |h, k| h[k] = [] }
+  end
 end

--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -25,7 +25,7 @@ class Balance < ApplicationRecord
 
   private
 
-    def favorable_direction
-      flows_factor == -1 ? "down" : "up"
-    end
+  def favorable_direction
+    flows_factor == -1 ? "down" : "up"
+  end
 end

--- a/app/models/balance/base_calculator.rb
+++ b/app/models/balance/base_calculator.rb
@@ -10,131 +10,131 @@ class Balance::BaseCalculator
   end
 
   private
-    def sync_cache
-      @sync_cache ||= Balance::SyncCache.new(account)
+  def sync_cache
+    @sync_cache ||= Balance::SyncCache.new(account)
+  end
+
+  def holdings_value_for_date(date)
+    @holdings_value_for_date ||= {}
+    @holdings_value_for_date[date] ||= sync_cache.get_holdings(date).sum(&:amount)
+  end
+
+  def derive_cash_balance_on_date_from_total(total_balance:, date:)
+    if account.balance_type == :investment
+      total_balance - holdings_value_for_date(date)
+    elsif account.balance_type == :cash
+      total_balance
+    else
+      0
+    end
+  end
+
+  def cash_adjustments_for_date(start_cash, end_cash, net_cash_flows)
+    return 0 unless account.balance_type != :non_cash
+
+    end_cash - start_cash - net_cash_flows
+  end
+
+  def non_cash_adjustments_for_date(start_non_cash, end_non_cash, non_cash_flows)
+    return 0 unless account.balance_type == :non_cash
+
+    end_non_cash - start_non_cash - non_cash_flows
+  end
+
+  # If holdings value goes from $100 -> $200 (change_holdings_value is $100)
+  # And non-cash flows (i.e. "buys") for day are +$50 (net_buy_sell_value is $50)
+  # That means value increased by $100, where $50 of that is due to the change in holdings value, and $50 is due to the buy/sell
+  def market_value_change_on_date(date, flows)
+    return 0 unless account.balance_type == :investment
+
+    start_of_day_holdings_value = holdings_value_for_date(date.prev_day)
+    end_of_day_holdings_value = holdings_value_for_date(date)
+
+    change_holdings_value = end_of_day_holdings_value - start_of_day_holdings_value
+    net_buy_sell_value = flows[:non_cash_inflows] - flows[:non_cash_outflows]
+
+    change_holdings_value - net_buy_sell_value
+  end
+
+  def flows_for_date(date)
+    entries = sync_cache.get_entries(date)
+
+    cash_inflows = 0
+    cash_outflows = 0
+    non_cash_inflows = 0
+    non_cash_outflows = 0
+
+    txn_inflow_sum = entries.select { |e| e.amount < 0 && e.transaction? }.sum(&:amount)
+    txn_outflow_sum = entries.select { |e| e.amount >= 0 && e.transaction? }.sum(&:amount)
+
+    trade_cash_inflow_sum = entries.select { |e| e.amount < 0 && e.trade? }.sum(&:amount)
+    trade_cash_outflow_sum = entries.select { |e| e.amount >= 0 && e.trade? }.sum(&:amount)
+
+    if account.balance_type == :non_cash && account.accountable_type == "Loan"
+      non_cash_inflows = txn_inflow_sum.abs
+      non_cash_outflows = txn_outflow_sum
+    elsif account.balance_type != :non_cash
+      cash_inflows = txn_inflow_sum.abs + trade_cash_inflow_sum.abs
+      cash_outflows = txn_outflow_sum + trade_cash_outflow_sum
+
+      # Trades are inverse (a "buy" is outflow of cash, but "inflow" of non-cash, aka "holdings")
+      non_cash_outflows = trade_cash_inflow_sum.abs
+      non_cash_inflows = trade_cash_outflow_sum
     end
 
-    def holdings_value_for_date(date)
-      @holdings_value_for_date ||= {}
-      @holdings_value_for_date[date] ||= sync_cache.get_holdings(date).sum(&:amount)
+    {
+      cash_inflows: cash_inflows,
+      cash_outflows: cash_outflows,
+      non_cash_inflows: non_cash_inflows,
+      non_cash_outflows: non_cash_outflows
+    }
+  end
+
+  def derive_cash_balance(cash_balance, date)
+    entries = sync_cache.get_entries(date)
+
+    if account.balance_type == :non_cash
+      0
+    else
+      cash_balance + signed_entry_flows(entries)
     end
+  end
 
-    def derive_cash_balance_on_date_from_total(total_balance:, date:)
-      if account.balance_type == :investment
-        total_balance - holdings_value_for_date(date)
-      elsif account.balance_type == :cash
-        total_balance
-      else
-        0
-      end
+  def derive_non_cash_balance(non_cash_balance, date, direction: :forward)
+    entries = sync_cache.get_entries(date)
+    # Loans are a special case (loan payment reducing principal, which is non-cash)
+    if account.balance_type == :non_cash && account.accountable_type == "Loan"
+      non_cash_balance + signed_entry_flows(entries)
+    elsif account.balance_type == :investment
+      # For reverse calculations, we need the previous day's holdings
+      target_date = direction == :forward ? date : date.prev_day
+      holdings_value_for_date(target_date)
+    else
+      non_cash_balance
     end
+  end
 
-    def cash_adjustments_for_date(start_cash, end_cash, net_cash_flows)
-      return 0 unless account.balance_type != :non_cash
+  def signed_entry_flows(entries)
+    raise NotImplementedError, "Directional calculators must implement this method"
+  end
 
-      end_cash - start_cash - net_cash_flows
-    end
-
-    def non_cash_adjustments_for_date(start_non_cash, end_non_cash, non_cash_flows)
-      return 0 unless account.balance_type == :non_cash
-
-      end_non_cash - start_non_cash - non_cash_flows
-    end
-
-    # If holdings value goes from $100 -> $200 (change_holdings_value is $100)
-    # And non-cash flows (i.e. "buys") for day are +$50 (net_buy_sell_value is $50)
-    # That means value increased by $100, where $50 of that is due to the change in holdings value, and $50 is due to the buy/sell
-    def market_value_change_on_date(date, flows)
-      return 0 unless account.balance_type == :investment
-
-      start_of_day_holdings_value = holdings_value_for_date(date.prev_day)
-      end_of_day_holdings_value = holdings_value_for_date(date)
-
-      change_holdings_value = end_of_day_holdings_value - start_of_day_holdings_value
-      net_buy_sell_value = flows[:non_cash_inflows] - flows[:non_cash_outflows]
-
-      change_holdings_value - net_buy_sell_value
-    end
-
-    def flows_for_date(date)
-      entries = sync_cache.get_entries(date)
-
-      cash_inflows = 0
-      cash_outflows = 0
-      non_cash_inflows = 0
-      non_cash_outflows = 0
-
-      txn_inflow_sum = entries.select { |e| e.amount < 0 && e.transaction? }.sum(&:amount)
-      txn_outflow_sum = entries.select { |e| e.amount >= 0 && e.transaction? }.sum(&:amount)
-
-      trade_cash_inflow_sum = entries.select { |e| e.amount < 0 && e.trade? }.sum(&:amount)
-      trade_cash_outflow_sum = entries.select { |e| e.amount >= 0 && e.trade? }.sum(&:amount)
-
-      if account.balance_type == :non_cash && account.accountable_type == "Loan"
-        non_cash_inflows = txn_inflow_sum.abs
-        non_cash_outflows = txn_outflow_sum
-      elsif account.balance_type != :non_cash
-        cash_inflows = txn_inflow_sum.abs + trade_cash_inflow_sum.abs
-        cash_outflows = txn_outflow_sum + trade_cash_outflow_sum
-
-        # Trades are inverse (a "buy" is outflow of cash, but "inflow" of non-cash, aka "holdings")
-        non_cash_outflows = trade_cash_inflow_sum.abs
-        non_cash_inflows = trade_cash_outflow_sum
-      end
-
-      {
-        cash_inflows: cash_inflows,
-        cash_outflows: cash_outflows,
-        non_cash_inflows: non_cash_inflows,
-        non_cash_outflows: non_cash_outflows
-      }
-    end
-
-    def derive_cash_balance(cash_balance, date)
-      entries = sync_cache.get_entries(date)
-
-      if account.balance_type == :non_cash
-        0
-      else
-        cash_balance + signed_entry_flows(entries)
-      end
-    end
-
-    def derive_non_cash_balance(non_cash_balance, date, direction: :forward)
-      entries = sync_cache.get_entries(date)
-      # Loans are a special case (loan payment reducing principal, which is non-cash)
-      if account.balance_type == :non_cash && account.accountable_type == "Loan"
-        non_cash_balance + signed_entry_flows(entries)
-      elsif account.balance_type == :investment
-        # For reverse calculations, we need the previous day's holdings
-        target_date = direction == :forward ? date : date.prev_day
-        holdings_value_for_date(target_date)
-      else
-        non_cash_balance
-      end
-    end
-
-    def signed_entry_flows(entries)
-      raise NotImplementedError, "Directional calculators must implement this method"
-    end
-
-    def build_balance(date:, **args)
-      Balance.new(
-        account_id: account.id,
-        currency: account.currency,
-        date: date,
-        balance: args[:balance],
-        cash_balance: args[:cash_balance],
-        start_cash_balance: args[:start_cash_balance] || 0,
-        start_non_cash_balance: args[:start_non_cash_balance] || 0,
-        cash_inflows: args[:cash_inflows] || 0,
-        cash_outflows: args[:cash_outflows] || 0,
-        non_cash_inflows: args[:non_cash_inflows] || 0,
-        non_cash_outflows: args[:non_cash_outflows] || 0,
-        cash_adjustments: args[:cash_adjustments] || 0,
-        non_cash_adjustments: args[:non_cash_adjustments] || 0,
-        net_market_flows: args[:net_market_flows] || 0,
-        flows_factor: account.classification == "asset" ? 1 : -1
-      )
-    end
+  def build_balance(date:, **args)
+    Balance.new(
+      account_id: account.id,
+      currency: account.currency,
+      date: date,
+      balance: args[:balance],
+      cash_balance: args[:cash_balance],
+      start_cash_balance: args[:start_cash_balance] || 0,
+      start_non_cash_balance: args[:start_non_cash_balance] || 0,
+      cash_inflows: args[:cash_inflows] || 0,
+      cash_outflows: args[:cash_outflows] || 0,
+      non_cash_inflows: args[:non_cash_inflows] || 0,
+      non_cash_outflows: args[:non_cash_outflows] || 0,
+      cash_adjustments: args[:cash_adjustments] || 0,
+      non_cash_adjustments: args[:non_cash_adjustments] || 0,
+      net_market_flows: args[:net_market_flows] || 0,
+      flows_factor: account.classification == "asset" ? 1 : -1
+    )
+  end
 end

--- a/app/models/balance/forward_calculator.rb
+++ b/app/models/balance/forward_calculator.rb
@@ -52,34 +52,34 @@ class Balance::ForwardCalculator < Balance::BaseCalculator
   end
 
   private
-    def calc_start_date
-      account.opening_anchor_date
-    end
+  def calc_start_date
+    account.opening_anchor_date
+  end
 
-    def calc_end_date
-      [account.entries.order(:date).last&.date, account.holdings.order(:date).last&.date].compact.max || Date.current
-    end
+  def calc_end_date
+    [account.entries.order(:date).last&.date, account.holdings.order(:date).last&.date].compact.max || Date.current
+  end
 
-    # Negative entries amount on an "asset" account means, "account value has increased"
-    # Negative entries amount on a "liability" account means, "account debt has decreased"
-    # Positive entries amount on an "asset" account means, "account value has decreased"
-    # Positive entries amount on a "liability" account means, "account debt has increased"
-    def signed_entry_flows(entries)
-      entry_flows = entries.sum(&:amount)
-      account.asset? ? -entry_flows : entry_flows
-    end
+  # Negative entries amount on an "asset" account means, "account value has increased"
+  # Negative entries amount on a "liability" account means, "account debt has decreased"
+  # Positive entries amount on an "asset" account means, "account value has decreased"
+  # Positive entries amount on a "liability" account means, "account debt has increased"
+  def signed_entry_flows(entries)
+    entry_flows = entries.sum(&:amount)
+    account.asset? ? -entry_flows : entry_flows
+  end
 
-    # Derives cash balance, starting from the start-of-day, applying entries in forward to get the end-of-day balance
-    def derive_end_cash_balance(start_cash_balance:, date:)
-      derive_cash_balance(start_cash_balance, date)
-    end
+  # Derives cash balance, starting from the start-of-day, applying entries in forward to get the end-of-day balance
+  def derive_end_cash_balance(start_cash_balance:, date:)
+    derive_cash_balance(start_cash_balance, date)
+  end
 
-    # Derives non-cash balance, starting from the start-of-day, applying entries in forward to get the end-of-day balance
-    def derive_end_non_cash_balance(start_non_cash_balance:, date:)
-      derive_non_cash_balance(start_non_cash_balance, date, direction: :forward)
-    end
+  # Derives non-cash balance, starting from the start-of-day, applying entries in forward to get the end-of-day balance
+  def derive_end_non_cash_balance(start_non_cash_balance:, date:)
+    derive_non_cash_balance(start_non_cash_balance, date, direction: :forward)
+  end
 
-    def flows_factor
-      account.asset? ? 1 : -1
-    end
+  def flows_factor
+    account.asset? ? 1 : -1
+  end
 end

--- a/app/models/balance/materializer.rb
+++ b/app/models/balance/materializer.rb
@@ -23,67 +23,67 @@ class Balance::Materializer
   end
 
   private
-    def materialize_holdings
-      @holdings = Holding::Materializer.new(account, strategy: strategy).materialize_holdings
+  def materialize_holdings
+    @holdings = Holding::Materializer.new(account, strategy: strategy).materialize_holdings
+  end
+
+  def update_account_info
+    # Query fresh balance from DB to get generated column values
+    current_balance = account.balances
+      .where(currency: account.currency)
+      .order(date: :desc)
+      .first
+
+    if current_balance
+      calculated_balance = current_balance.end_balance
+      calculated_cash_balance = current_balance.end_cash_balance
+    else
+      # Fallback if no balance exists
+      calculated_balance = 0
+      calculated_cash_balance = 0
     end
 
-    def update_account_info
-      # Query fresh balance from DB to get generated column values
-      current_balance = account.balances
-        .where(currency: account.currency)
-        .order(date: :desc)
-        .first
+    Rails.logger.info("Balance update: cash=#{calculated_cash_balance}, total=#{calculated_balance}")
 
-      if current_balance
-        calculated_balance = current_balance.end_balance
-        calculated_cash_balance = current_balance.end_cash_balance
-      else
-        # Fallback if no balance exists
-        calculated_balance = 0
-        calculated_cash_balance = 0
-      end
+    account.update!(
+      balance: calculated_balance,
+      cash_balance: calculated_cash_balance
+    )
+  end
 
-      Rails.logger.info("Balance update: cash=#{calculated_cash_balance}, total=#{calculated_balance}")
+  def calculate_balances
+    @balances = calculator.calculate
+  end
 
-      account.update!(
-        balance: calculated_balance,
-        cash_balance: calculated_cash_balance
-      )
+  def persist_balances
+    current_time = Time.now
+    account.balances.upsert_all(
+      @balances.map { |b| b.attributes
+             .slice("date", "balance", "cash_balance", "currency",
+                    "start_cash_balance", "start_non_cash_balance",
+                    "cash_inflows", "cash_outflows",
+                    "non_cash_inflows", "non_cash_outflows",
+                    "net_market_flows",
+                    "cash_adjustments", "non_cash_adjustments",
+                    "flows_factor")
+             .merge("updated_at" => current_time) },
+      unique_by: %i[account_id date currency]
+    )
+  end
+
+  def purge_stale_balances
+    sorted_balances = @balances.sort_by(&:date)
+    oldest_calculated_balance_date = sorted_balances.first&.date
+    newest_calculated_balance_date = sorted_balances.last&.date
+    deleted_count = account.balances.delete_by("date < ? OR date > ?", oldest_calculated_balance_date, newest_calculated_balance_date)
+    Rails.logger.info("Purged #{deleted_count} stale balances") if deleted_count > 0
+  end
+
+  def calculator
+    if strategy == :reverse
+      Balance::ReverseCalculator.new(account)
+    else
+      Balance::ForwardCalculator.new(account)
     end
-
-    def calculate_balances
-      @balances = calculator.calculate
-    end
-
-    def persist_balances
-      current_time = Time.now
-      account.balances.upsert_all(
-        @balances.map { |b| b.attributes
-               .slice("date", "balance", "cash_balance", "currency",
-                      "start_cash_balance", "start_non_cash_balance",
-                      "cash_inflows", "cash_outflows",
-                      "non_cash_inflows", "non_cash_outflows",
-                      "net_market_flows",
-                      "cash_adjustments", "non_cash_adjustments",
-                      "flows_factor")
-               .merge("updated_at" => current_time) },
-        unique_by: %i[account_id date currency]
-      )
-    end
-
-    def purge_stale_balances
-      sorted_balances = @balances.sort_by(&:date)
-      oldest_calculated_balance_date = sorted_balances.first&.date
-      newest_calculated_balance_date = sorted_balances.last&.date
-      deleted_count = account.balances.delete_by("date < ? OR date > ?", oldest_calculated_balance_date, newest_calculated_balance_date)
-      Rails.logger.info("Purged #{deleted_count} stale balances") if deleted_count > 0
-    end
-
-    def calculator
-      if strategy == :reverse
-        Balance::ReverseCalculator.new(account)
-      else
-        Balance::ForwardCalculator.new(account)
-      end
-    end
+  end
 end

--- a/app/models/balance/reverse_calculator.rb
+++ b/app/models/balance/reverse_calculator.rb
@@ -52,31 +52,31 @@ class Balance::ReverseCalculator < Balance::BaseCalculator
 
   private
 
-    # Negative entries amount on an "asset" account means, "account value has increased"
-    # Negative entries amount on a "liability" account means, "account debt has decreased"
-    # Positive entries amount on an "asset" account means, "account value has decreased"
-    # Positive entries amount on a "liability" account means, "account debt has increased"
-    def signed_entry_flows(entries)
-      entry_flows = entries.sum(&:amount)
-      account.asset? ? entry_flows : -entry_flows
-    end
+  # Negative entries amount on an "asset" account means, "account value has increased"
+  # Negative entries amount on a "liability" account means, "account debt has decreased"
+  # Positive entries amount on an "asset" account means, "account value has decreased"
+  # Positive entries amount on a "liability" account means, "account debt has increased"
+  def signed_entry_flows(entries)
+    entry_flows = entries.sum(&:amount)
+    account.asset? ? entry_flows : -entry_flows
+  end
 
-    # Alias method, for algorithmic clarity
-    # Derives cash balance, starting from the end-of-day, applying entries in reverse to get the start-of-day balance
-    def derive_start_cash_balance(end_cash_balance:, date:)
-      derive_cash_balance(end_cash_balance, date)
-    end
+  # Alias method, for algorithmic clarity
+  # Derives cash balance, starting from the end-of-day, applying entries in reverse to get the start-of-day balance
+  def derive_start_cash_balance(end_cash_balance:, date:)
+    derive_cash_balance(end_cash_balance, date)
+  end
 
-    # Alias method, for algorithmic clarity
-    # Derives non-cash balance, starting from the end-of-day, applying entries in reverse to get the start-of-day balance
-    def derive_start_non_cash_balance(end_non_cash_balance:, date:)
-      derive_non_cash_balance(end_non_cash_balance, date, direction: :reverse)
-    end
+  # Alias method, for algorithmic clarity
+  # Derives non-cash balance, starting from the end-of-day, applying entries in reverse to get the start-of-day balance
+  def derive_start_non_cash_balance(end_non_cash_balance:, date:)
+    derive_non_cash_balance(end_non_cash_balance, date, direction: :reverse)
+  end
 
-    # Reverse syncs are a bit different than forward syncs because we do not allow "reconciliation" valuations
-    # to be used at all. This is primarily to keep the code and the UI easy to understand. For a more detailed
-    # explanation, see the test suite.
-    def use_opening_anchor_for_date?(date)
-      account.has_opening_anchor? && date == account.opening_anchor_date
-    end
+  # Reverse syncs are a bit different than forward syncs because we do not allow "reconciliation" valuations
+  # to be used at all. This is primarily to keep the code and the UI easy to understand. For a more detailed
+  # explanation, see the test suite.
+  def use_opening_anchor_for_date?(date)
+    account.has_opening_anchor? && date == account.opening_anchor_date
+  end
 end

--- a/app/models/balance/sync_cache.rb
+++ b/app/models/balance/sync_cache.rb
@@ -16,31 +16,31 @@ class Balance::SyncCache
   end
 
   private
-    attr_reader :account
+  attr_reader :account
 
-    def converted_entries
-      @converted_entries ||= account.entries.order(:date).to_a.map do |e|
-        converted_entry = e.dup
-        converted_entry.amount = converted_entry.amount_money.exchange_to(
-          account.currency,
-          date: e.date,
-          fallback_rate: 1
-        ).amount
-        converted_entry.currency = account.currency
-        converted_entry
-      end
+  def converted_entries
+    @converted_entries ||= account.entries.order(:date).to_a.map do |e|
+      converted_entry = e.dup
+      converted_entry.amount = converted_entry.amount_money.exchange_to(
+        account.currency,
+        date: e.date,
+        fallback_rate: 1
+      ).amount
+      converted_entry.currency = account.currency
+      converted_entry
     end
+  end
 
-    def converted_holdings
-      @converted_holdings ||= account.holdings.map do |h|
-        converted_holding = h.dup
-        converted_holding.amount = converted_holding.amount_money.exchange_to(
-          account.currency,
-          date: h.date,
-          fallback_rate: 1
-        ).amount
-        converted_holding.currency = account.currency
-        converted_holding
-      end
+  def converted_holdings
+    @converted_holdings ||= account.holdings.map do |h|
+      converted_holding = h.dup
+      converted_holding.amount = converted_holding.amount_money.exchange_to(
+        account.currency,
+        date: h.date,
+        fallback_rate: 1
+      ).amount
+      converted_holding.currency = account.currency
+      converted_holding
     end
+  end
 end

--- a/app/models/balance_sheet.rb
+++ b/app/models/balance_sheet.rb
@@ -54,19 +54,19 @@ class BalanceSheet
   end
 
   private
-    def sync_status_monitor
-      @sync_status_monitor ||= SyncStatusMonitor.new(family)
-    end
+  def sync_status_monitor
+    @sync_status_monitor ||= SyncStatusMonitor.new(family)
+  end
 
-    def account_totals
-      @account_totals ||= AccountTotals.new(family, sync_status_monitor: sync_status_monitor)
-    end
+  def account_totals
+    @account_totals ||= AccountTotals.new(family, sync_status_monitor: sync_status_monitor)
+  end
 
-    def net_worth_series_builder
-      @net_worth_series_builder ||= NetWorthSeriesBuilder.new(family)
-    end
+  def net_worth_series_builder
+    @net_worth_series_builder ||= NetWorthSeriesBuilder.new(family)
+  end
 
-    def categorised_series_builder
-      @categorised_series_builder ||= CategorisedSeriesBuilder.new(family)
-    end
+  def categorised_series_builder
+    @categorised_series_builder ||= CategorisedSeriesBuilder.new(family)
+  end
 end

--- a/app/models/balance_sheet/account_group.rb
+++ b/app/models/balance_sheet/account_group.rb
@@ -57,5 +57,5 @@ class BalanceSheet::AccountGroup
   end
 
   private
-    attr_reader :classification_group
+  attr_reader :classification_group
 end

--- a/app/models/balance_sheet/account_totals.rb
+++ b/app/models/balance_sheet/account_totals.rb
@@ -13,51 +13,51 @@ class BalanceSheet::AccountTotals
   end
 
   private
-    attr_reader :family, :sync_status_monitor
+  attr_reader :family, :sync_status_monitor
 
-    AccountRow = Data.define(:account, :converted_balance, :is_syncing) do
-      def syncing? = is_syncing
+  AccountRow = Data.define(:account, :converted_balance, :is_syncing) do
+    def syncing? = is_syncing
 
-      # Allows Rails path helpers to generate URLs from the wrapper
-      def to_param = account.to_param
-      delegate_missing_to :account
-    end
+    # Allows Rails path helpers to generate URLs from the wrapper
+    def to_param = account.to_param
+    delegate_missing_to :account
+  end
 
-    def visible_accounts
-      @visible_accounts ||= family.accounts.visible.with_attached_logo
-    end
+  def visible_accounts
+    @visible_accounts ||= family.accounts.visible.with_attached_logo
+  end
 
-    def account_rows
-      @account_rows ||= query.map do |account_row|
-        AccountRow.new(
-          account: account_row,
-          converted_balance: account_row.converted_balance,
-          is_syncing: sync_status_monitor.account_syncing?(account_row)
-        )
-      end
-    end
-
-    def cache_key
-      family.build_cache_key(
-        "balance_sheet_account_rows",
-        invalidate_on_data_updates: true
+  def account_rows
+    @account_rows ||= query.map do |account_row|
+      AccountRow.new(
+        account: account_row,
+        converted_balance: account_row.converted_balance,
+        is_syncing: sync_status_monitor.account_syncing?(account_row)
       )
     end
+  end
 
-    def query
-      @query ||= Rails.cache.fetch(cache_key) do
-        visible_accounts
-          .joins(ActiveRecord::Base.sanitize_sql_array([
-            "LEFT JOIN exchange_rates ON exchange_rates.date = ? AND accounts.currency = exchange_rates.from_currency AND exchange_rates.to_currency = ?",
-            Date.current,
-            family.currency
-          ]))
-          .select(
-            "accounts.*",
-            "SUM(accounts.balance * COALESCE(exchange_rates.rate, 1)) as converted_balance"
-          )
-          .group(:classification, :accountable_type, :id)
-          .to_a
-      end
+  def cache_key
+    family.build_cache_key(
+      "balance_sheet_account_rows",
+      invalidate_on_data_updates: true
+    )
+  end
+
+  def query
+    @query ||= Rails.cache.fetch(cache_key) do
+      visible_accounts
+        .joins(ActiveRecord::Base.sanitize_sql_array([
+          "LEFT JOIN exchange_rates ON exchange_rates.date = ? AND accounts.currency = exchange_rates.from_currency AND exchange_rates.to_currency = ?",
+          Date.current,
+          family.currency
+        ]))
+        .select(
+          "accounts.*",
+          "SUM(accounts.balance * COALESCE(exchange_rates.rate, 1)) as converted_balance"
+        )
+        .group(:classification, :accountable_type, :id)
+        .to_a
     end
+  end
 end

--- a/app/models/balance_sheet/categorised_series_builder.rb
+++ b/app/models/balance_sheet/categorised_series_builder.rb
@@ -19,23 +19,23 @@ class BalanceSheet::CategorisedSeriesBuilder
   end
 
   private
-    attr_reader :family
+  attr_reader :family
 
-    def visible_account_ids
-      @visible_account_ids ||= family.accounts.visible.with_attached_logo.pluck(:id)
-    end
+  def visible_account_ids
+    @visible_account_ids ||= family.accounts.visible.with_attached_logo.pluck(:id)
+  end
 
-    def cache_key(period, category_id)
-      key = [
-        "balance_sheet_categorised_series",
-        period.start_date,
-        period.end_date,
-        category_id
-      ].compact.join("_")
+  def cache_key(period, category_id)
+    key = [
+      "balance_sheet_categorised_series",
+      period.start_date,
+      period.end_date,
+      category_id
+    ].compact.join("_")
 
-      family.build_cache_key(
-        key,
-        invalidate_on_data_updates: true
-      )
-    end
+    family.build_cache_key(
+      key,
+      invalidate_on_data_updates: true
+    )
+  end
 end

--- a/app/models/balance_sheet/classification_group.rb
+++ b/app/models/balance_sheet/classification_group.rb
@@ -52,10 +52,10 @@ class BalanceSheet::ClassificationGroup
   end
 
   private
-    attr_reader :accounts
+  attr_reader :accounts
 
-    def normalize_classification!(classification)
-      raise ArgumentError, "Invalid classification: #{classification}" unless %w[asset liability].include?(classification)
-      classification
-    end
+  def normalize_classification!(classification)
+    raise ArgumentError, "Invalid classification: #{classification}" unless %w[asset liability].include?(classification)
+    classification
+  end
 end

--- a/app/models/balance_sheet/net_worth_series_builder.rb
+++ b/app/models/balance_sheet/net_worth_series_builder.rb
@@ -17,22 +17,22 @@ class BalanceSheet::NetWorthSeriesBuilder
   end
 
   private
-    attr_reader :family
+  attr_reader :family
 
-    def visible_account_ids
-      @visible_account_ids ||= family.accounts.visible.with_attached_logo.pluck(:id)
-    end
+  def visible_account_ids
+    @visible_account_ids ||= family.accounts.visible.with_attached_logo.pluck(:id)
+  end
 
-    def cache_key(period)
-      key = [
-        "balance_sheet_net_worth_series",
-        period.start_date,
-        period.end_date
-      ].compact.join("_")
+  def cache_key(period)
+    key = [
+      "balance_sheet_net_worth_series",
+      period.start_date,
+      period.end_date
+    ].compact.join("_")
 
-      family.build_cache_key(
-        key,
-        invalidate_on_data_updates: true
-      )
-    end
+    family.build_cache_key(
+      key,
+      invalidate_on_data_updates: true
+    )
+  end
 end

--- a/app/models/balance_sheet/sync_status_monitor.rb
+++ b/app/models/balance_sheet/sync_status_monitor.rb
@@ -12,24 +12,24 @@ class BalanceSheet::SyncStatusMonitor
   end
 
   private
-    attr_reader :family
+  attr_reader :family
 
-    def syncing_account_ids
-      Rails.cache.fetch(cache_key) do
-        Sync.visible
-            .where(syncable_type: "Account", syncable_id: family.accounts.visible.pluck(:id))
-            .pluck(:syncable_id)
-            .to_set
-      end
+  def syncing_account_ids
+    Rails.cache.fetch(cache_key) do
+      Sync.visible
+          .where(syncable_type: "Account", syncable_id: family.accounts.visible.pluck(:id))
+          .pluck(:syncable_id)
+          .to_set
     end
+  end
 
-    # We re-fetch the set of syncing IDs any time a sync that belongs to the family is started or completed.
-    # This ensures we're always fetching the latest sync statuses without re-querying on every page load in idle times (no syncs happening).
-    def cache_key
-      [
-        "balance_sheet_sync_status",
-        family.id,
-        family.latest_sync_activity_at
-      ].join("_")
-    end
+  # We re-fetch the set of syncing IDs any time a sync that belongs to the family is started or completed.
+  # This ensures we're always fetching the latest sync statuses without re-querying on every page load in idle times (no syncs happening).
+  def cache_key
+    [
+      "balance_sheet_sync_status",
+      family.id,
+      family.latest_sync_activity_at
+    ].join("_")
+  end
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -48,12 +48,12 @@ class Budget < ApplicationRecord
     end
 
     private
-      def oldest_valid_budget_date(family)
-        # Allow going back to either the earliest entry date OR 2 years ago, whichever is earlier
-        two_years_ago = 2.years.ago.beginning_of_month
-        oldest_entry_date = family.oldest_entry_date.beginning_of_month
-        [two_years_ago, oldest_entry_date].min
-      end
+    def oldest_valid_budget_date(family)
+      # Allow going back to either the earliest entry date OR 2 years ago, whichever is earlier
+      two_years_ago = 2.years.ago.beginning_of_month
+      oldest_entry_date = family.oldest_entry_date.beginning_of_month
+      [two_years_ago, oldest_entry_date].min
+    end
   end
 
   def period
@@ -235,15 +235,15 @@ class Budget < ApplicationRecord
   end
 
   private
-    def income_statement
-      @income_statement ||= family.income_statement
-    end
+  def income_statement
+    @income_statement ||= family.income_statement
+  end
 
-    def expense_totals
-      @expense_totals ||= income_statement.expense_totals(period: period)
-    end
+  def expense_totals
+    @expense_totals ||= income_statement.expense_totals(period: period)
+  end
 
-    def income_totals
-      @income_totals ||= family.income_statement.income_totals(period: period)
-    end
+  def income_totals
+    @income_totals ||= family.income_statement.income_totals(period: period)
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -73,24 +73,24 @@ class Category < ApplicationRecord
     end
 
     private
-      def default_categories
-        [
-          ["Income", "#e99537", "circle-dollar-sign", "income"],
-          ["Loan Payments", "#6471eb", "credit-card", "expense"],
-          ["Fees", "#6471eb", "credit-card", "expense"],
-          ["Entertainment", "#df4e92", "drama", "expense"],
-          ["Food & Drink", "#eb5429", "utensils", "expense"],
-          ["Shopping", "#e99537", "shopping-cart", "expense"],
-          ["Home Improvement", "#6471eb", "house", "expense"],
-          ["Healthcare", "#4da568", "pill", "expense"],
-          ["Personal Care", "#4da568", "pill", "expense"],
-          ["Services", "#4da568", "briefcase", "expense"],
-          ["Gifts & Donations", "#61c9ea", "hand-helping", "expense"],
-          ["Transportation", "#df4e92", "bus", "expense"],
-          ["Travel", "#df4e92", "plane", "expense"],
-          ["Rent & Utilities", "#db5a54", "lightbulb", "expense"]
-        ]
-      end
+    def default_categories
+      [
+        ["Income", "#e99537", "circle-dollar-sign", "income"],
+        ["Loan Payments", "#6471eb", "credit-card", "expense"],
+        ["Fees", "#6471eb", "credit-card", "expense"],
+        ["Entertainment", "#df4e92", "drama", "expense"],
+        ["Food & Drink", "#eb5429", "utensils", "expense"],
+        ["Shopping", "#e99537", "shopping-cart", "expense"],
+        ["Home Improvement", "#6471eb", "house", "expense"],
+        ["Healthcare", "#4da568", "pill", "expense"],
+        ["Personal Care", "#4da568", "pill", "expense"],
+        ["Services", "#4da568", "briefcase", "expense"],
+        ["Gifts & Donations", "#61c9ea", "hand-helping", "expense"],
+        ["Transportation", "#df4e92", "bus", "expense"],
+        ["Travel", "#df4e92", "plane", "expense"],
+        ["Rent & Utilities", "#db5a54", "lightbulb", "expense"]
+      ]
+    end
   end
 
   def inherit_color_from_parent
@@ -115,19 +115,19 @@ class Category < ApplicationRecord
   end
 
   private
-    def category_level_limit
-      if (subcategory? && parent.subcategory?) || (parent? && subcategory?)
-        errors.add(:parent, "can't have more than 2 levels of subcategories")
-      end
+  def category_level_limit
+    if (subcategory? && parent.subcategory?) || (parent? && subcategory?)
+      errors.add(:parent, "can't have more than 2 levels of subcategories")
     end
+  end
 
-    def nested_category_matches_parent_classification
-      if subcategory? && parent.classification != classification
-        errors.add(:parent, "must have the same classification as its parent")
-      end
+  def nested_category_matches_parent_classification
+    if subcategory? && parent.classification != classification
+      errors.add(:parent, "must have the same classification as its parent")
     end
+  end
 
-    def monetizable_currency
-      family.currency
-    end
+  def monetizable_currency
+    family.currency
+  end
 end

--- a/app/models/concerns/enrichable.rb
+++ b/app/models/concerns/enrichable.rb
@@ -73,19 +73,19 @@ module Enrichable
   end
 
   private
-    def log_enrichment(attribute_name:, attribute_value:, source:, metadata: {})
-      de = DataEnrichment.find_or_create_by(
-        enrichable: self,
-        attribute_name: attribute_name,
-        source: source,
-      )
+  def log_enrichment(attribute_name:, attribute_value:, source:, metadata: {})
+    de = DataEnrichment.find_or_create_by(
+      enrichable: self,
+      attribute_name: attribute_name,
+      source: source,
+    )
 
-      de.value = attribute_value
-      de.metadata = metadata
-      de.save
-    end
+    de.value = attribute_value
+    de.metadata = metadata
+    de.save
+  end
 
-    def ignored_enrichable_attributes
-      %w[id updated_at created_at]
-    end
+  def ignored_enrichable_attributes
+    %w[id updated_at created_at]
+  end
 end

--- a/app/models/concerns/monetizable.rb
+++ b/app/models/concerns/monetizable.rb
@@ -16,7 +16,7 @@ module Monetizable
   end
 
   private
-    def monetizable_currency
-      currency
-    end
+  def monetizable_currency
+    currency
+  end
 end

--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -59,15 +59,15 @@ module Syncable
   end
 
   private
-    def latest_sync
-      syncs.ordered.first
-    end
+  def latest_sync
+    syncs.ordered.first
+  end
 
-    def syncer
-      self.class::Syncer.new(self)
-    end
+  def syncer
+    self.class::Syncer.new(self)
+  end
 
-    def sync_broadcaster
-      self.class::SyncCompleteEvent.new(self)
-    end
+  def sync_broadcaster
+    self.class::SyncCompleteEvent.new(self)
+  end
 end

--- a/app/models/demo/data_cleaner.rb
+++ b/app/models/demo/data_cleaner.rb
@@ -20,9 +20,9 @@ class Demo::DataCleaner
 
   private
 
-    def ensure_safe_environment!
-      unless SAFE_ENVIRONMENTS.include?(Rails.env)
-        raise SecurityError, "Demo::DataCleaner can only be used in #{SAFE_ENVIRONMENTS.join(', ')} environments. Current: #{Rails.env}"
-      end
+  def ensure_safe_environment!
+    unless SAFE_ENVIRONMENTS.include?(Rails.env)
+      raise SecurityError, "Demo::DataCleaner can only be used in #{SAFE_ENVIRONMENTS.join(', ')} environments. Current: #{Rails.env}"
     end
+  end
 end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -85,1135 +85,1135 @@ class Demo::Generator
 
   private
 
-    # Simple timing helper. Pass a descriptive label and a block; the runtime
-    # will be printed automatically when the block completes.
-    # If max_seconds is provided, raise RuntimeError when the block exceeds that
-    # duration.  Useful to keep CI/dev machines honest about demo-data perf.
-    def with_timing(label, max_seconds: nil)
-      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = yield
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-      puts "⏱️  #{label} completed in #{duration.round(2)}s"
+  # Simple timing helper. Pass a descriptive label and a block; the runtime
+  # will be printed automatically when the block completes.
+  # If max_seconds is provided, raise RuntimeError when the block exceeds that
+  # duration.  Useful to keep CI/dev machines honest about demo-data perf.
+  def with_timing(label, max_seconds: nil)
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = yield
+    duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    puts "⏱️  #{label} completed in #{duration.round(2)}s"
 
-      if max_seconds && duration > max_seconds
-        raise "Demo::Generator ##{label} exceeded #{max_seconds}s (#{duration.round(2)}s)"
-      end
-
-      result
+    if max_seconds && duration > max_seconds
+      raise "Demo::Generator ##{label} exceeded #{max_seconds}s (#{duration.round(2)}s)"
     end
 
-    # Override Kernel#rand so *all* `rand` calls inside this instance (including
-    # those already present in the file) are routed through the seeded PRNG.
-    def rand(*args)
-      @rng.rand(*args)
+    result
+  end
+
+  # Override Kernel#rand so *all* `rand` calls inside this instance (including
+  # those already present in the file) are routed through the seeded PRNG.
+  def rand(*args)
+    @rng.rand(*args)
+  end
+
+
+
+  def clear_all_data!
+    family_count = Family.count
+    if family_count > 50
+      raise "Too much data to clear efficiently (#{family_count} families). Run 'rails db:reset' instead."
     end
+    Demo::DataCleaner.new.destroy_everything!
+  end
 
+  def create_family_and_users!(family_name, email, onboarded:, subscribed:)
+    family = Family.create!(
+      name: family_name,
+      currency: "USD",
+      locale: "en",
+      country: "US",
+      timezone: "America/New_York",
+      date_format: "%m-%d-%Y"
+    )
 
+    family.start_subscription!("sub_demo_123") if subscribed
 
-    def clear_all_data!
-      family_count = Family.count
-      if family_count > 50
-        raise "Too much data to clear efficiently (#{family_count} families). Run 'rails db:reset' instead."
-      end
-      Demo::DataCleaner.new.destroy_everything!
-    end
+    # Admin user
+    family.users.create!(
+      email: email,
+      first_name: "Demo (admin)",
+      last_name: "Maybe",
+      role: "admin",
+      password: "password",
+      onboarded_at: onboarded ? Time.current : nil
+    )
 
-    def create_family_and_users!(family_name, email, onboarded:, subscribed:)
-      family = Family.create!(
-        name: family_name,
-        currency: "USD",
-        locale: "en",
-        country: "US",
-        timezone: "America/New_York",
-        date_format: "%m-%d-%Y"
-      )
+    # Member user
+    family.users.create!(
+      email: "partner_#{email}",
+      first_name: "Demo (member)",
+      last_name: "Maybe",
+      role: "member",
+      password: "password",
+      onboarded_at: onboarded ? Time.current : nil
+    )
 
-      family.start_subscription!("sub_demo_123") if subscribed
+    family
+  end
 
-      # Admin user
-      family.users.create!(
-        email: email,
-        first_name: "Demo (admin)",
-        last_name: "Maybe",
-        role: "admin",
-        password: "password",
-        onboarded_at: onboarded ? Time.current : nil
-      )
+  def create_realistic_categories!(family)
+    # Income categories (3 total)
+    @salary_cat = family.categories.create!(name: "Salary", color: "#10b981", classification: "income")
+    @freelance_cat = family.categories.create!(name: "Freelance", color: "#059669", classification: "income")
+    @investment_income_cat = family.categories.create!(name: "Investment Income", color: "#047857", classification: "income")
 
-      # Member user
-      family.users.create!(
-        email: "partner_#{email}",
-        first_name: "Demo (member)",
-        last_name: "Maybe",
-        role: "member",
-        password: "password",
-        onboarded_at: onboarded ? Time.current : nil
-      )
+    # Expense categories with subcategories (12 total)
+    @housing_cat = family.categories.create!(name: "Housing", color: "#dc2626", classification: "expense")
+    @rent_cat = family.categories.create!(name: "Rent/Mortgage", parent: @housing_cat, color: "#b91c1c", classification: "expense")
+    @utilities_cat = family.categories.create!(name: "Utilities", parent: @housing_cat, color: "#991b1b", classification: "expense")
 
-      family
-    end
+    @food_cat = family.categories.create!(name: "Food & Dining", color: "#ea580c", classification: "expense")
+    @groceries_cat = family.categories.create!(name: "Groceries", parent: @food_cat, color: "#c2410c", classification: "expense")
+    @restaurants_cat = family.categories.create!(name: "Restaurants", parent: @food_cat, color: "#9a3412", classification: "expense")
+    @coffee_cat = family.categories.create!(name: "Coffee & Takeout", parent: @food_cat, color: "#7c2d12", classification: "expense")
 
-    def create_realistic_categories!(family)
-      # Income categories (3 total)
-      @salary_cat = family.categories.create!(name: "Salary", color: "#10b981", classification: "income")
-      @freelance_cat = family.categories.create!(name: "Freelance", color: "#059669", classification: "income")
-      @investment_income_cat = family.categories.create!(name: "Investment Income", color: "#047857", classification: "income")
+    @transportation_cat = family.categories.create!(name: "Transportation", color: "#2563eb", classification: "expense")
+    @gas_cat = family.categories.create!(name: "Gas", parent: @transportation_cat, color: "#1d4ed8", classification: "expense")
+    @car_payment_cat = family.categories.create!(name: "Car Payment", parent: @transportation_cat, color: "#1e40af", classification: "expense")
 
-      # Expense categories with subcategories (12 total)
-      @housing_cat = family.categories.create!(name: "Housing", color: "#dc2626", classification: "expense")
-      @rent_cat = family.categories.create!(name: "Rent/Mortgage", parent: @housing_cat, color: "#b91c1c", classification: "expense")
-      @utilities_cat = family.categories.create!(name: "Utilities", parent: @housing_cat, color: "#991b1b", classification: "expense")
+    @entertainment_cat = family.categories.create!(name: "Entertainment", color: "#7c3aed", classification: "expense")
+    @healthcare_cat = family.categories.create!(name: "Healthcare", color: "#db2777", classification: "expense")
+    @shopping_cat = family.categories.create!(name: "Shopping", color: "#059669", classification: "expense")
+    @travel_cat = family.categories.create!(name: "Travel", color: "#0891b2", classification: "expense")
+    @personal_care_cat = family.categories.create!(name: "Personal Care", color: "#be185d", classification: "expense")
 
-      @food_cat = family.categories.create!(name: "Food & Dining", color: "#ea580c", classification: "expense")
-      @groceries_cat = family.categories.create!(name: "Groceries", parent: @food_cat, color: "#c2410c", classification: "expense")
-      @restaurants_cat = family.categories.create!(name: "Restaurants", parent: @food_cat, color: "#9a3412", classification: "expense")
-      @coffee_cat = family.categories.create!(name: "Coffee & Takeout", parent: @food_cat, color: "#7c2d12", classification: "expense")
+    # Additional high-level expense categories to reach 13 top-level items
+    @insurance_cat = family.categories.create!(name: "Insurance", color: "#6366f1", classification: "expense")
+    @misc_cat      = family.categories.create!(name: "Miscellaneous", color: "#6b7280", classification: "expense")
 
-      @transportation_cat = family.categories.create!(name: "Transportation", color: "#2563eb", classification: "expense")
-      @gas_cat = family.categories.create!(name: "Gas", parent: @transportation_cat, color: "#1d4ed8", classification: "expense")
-      @car_payment_cat = family.categories.create!(name: "Car Payment", parent: @transportation_cat, color: "#1e40af", classification: "expense")
+    # Interest expense bucket
+    @interest_cat = family.categories.create!(name: "Loan Interest", color: "#475569", classification: "expense")
+  end
 
-      @entertainment_cat = family.categories.create!(name: "Entertainment", color: "#7c3aed", classification: "expense")
-      @healthcare_cat = family.categories.create!(name: "Healthcare", color: "#db2777", classification: "expense")
-      @shopping_cat = family.categories.create!(name: "Shopping", color: "#059669", classification: "expense")
-      @travel_cat = family.categories.create!(name: "Travel", color: "#0891b2", classification: "expense")
-      @personal_care_cat = family.categories.create!(name: "Personal Care", color: "#be185d", classification: "expense")
+  def create_realistic_accounts!(family)
+    # Checking accounts (USD)
+    @chase_checking = family.accounts.create!(accountable: Depository.new, name: "Chase Premier Checking", balance: 0, currency: "USD")
+    @ally_checking = family.accounts.create!(accountable: Depository.new, name: "Ally Online Checking", balance: 0, currency: "USD")
 
-      # Additional high-level expense categories to reach 13 top-level items
-      @insurance_cat = family.categories.create!(name: "Insurance", color: "#6366f1", classification: "expense")
-      @misc_cat      = family.categories.create!(name: "Miscellaneous", color: "#6b7280", classification: "expense")
+    # Savings account (USD)
+    @marcus_savings = family.accounts.create!(accountable: Depository.new, name: "Marcus High-Yield Savings", balance: 0, currency: "USD")
 
-      # Interest expense bucket
-      @interest_cat = family.categories.create!(name: "Loan Interest", color: "#475569", classification: "expense")
-    end
+    # EUR checking (EUR)
+    @eu_checking = family.accounts.create!(accountable: Depository.new, name: "Deutsche Bank EUR Account", balance: 0, currency: "EUR")
 
-    def create_realistic_accounts!(family)
-      # Checking accounts (USD)
-      @chase_checking = family.accounts.create!(accountable: Depository.new, name: "Chase Premier Checking", balance: 0, currency: "USD")
-      @ally_checking = family.accounts.create!(accountable: Depository.new, name: "Ally Online Checking", balance: 0, currency: "USD")
+    # Credit cards (USD)
+    @amex_gold = family.accounts.create!(accountable: CreditCard.new, name: "Amex Gold Card", balance: 0, currency: "USD")
+    @chase_sapphire = family.accounts.create!(accountable: CreditCard.new, name: "Chase Sapphire Reserve", balance: 0, currency: "USD")
 
-      # Savings account (USD)
-      @marcus_savings = family.accounts.create!(accountable: Depository.new, name: "Marcus High-Yield Savings", balance: 0, currency: "USD")
+    # Investment accounts (USD + GBP)
+    @vanguard_401k     = family.accounts.create!(accountable: Investment.new, name: "Vanguard 401(k)", balance: 0, currency: "USD")
+    @schwab_brokerage  = family.accounts.create!(accountable: Investment.new, name: "Charles Schwab Brokerage", balance: 0, currency: "USD")
+    @fidelity_roth_ira = family.accounts.create!(accountable: Investment.new, name: "Fidelity Roth IRA", balance: 0, currency: "USD")
+    @hsa_investment    = family.accounts.create!(accountable: Investment.new, name: "Fidelity HSA Investment", balance: 0, currency: "USD")
+    @uk_isa           = family.accounts.create!(accountable: Investment.new, name: "Vanguard UK ISA", balance: 0, currency: "GBP")
 
-      # EUR checking (EUR)
-      @eu_checking = family.accounts.create!(accountable: Depository.new, name: "Deutsche Bank EUR Account", balance: 0, currency: "EUR")
+    # Property (USD)
+    @home = family.accounts.create!(accountable: Property.new, name: "Primary Residence", balance: 0, currency: "USD")
 
-      # Credit cards (USD)
-      @amex_gold = family.accounts.create!(accountable: CreditCard.new, name: "Amex Gold Card", balance: 0, currency: "USD")
-      @chase_sapphire = family.accounts.create!(accountable: CreditCard.new, name: "Chase Sapphire Reserve", balance: 0, currency: "USD")
+    # Vehicles (USD)
+    @honda_accord = family.accounts.create!(accountable: Vehicle.new, name: "2016 Honda Accord", balance: 0, currency: "USD")
+    @tesla_model3 = family.accounts.create!(accountable: Vehicle.new, name: "2021 Tesla Model 3", balance: 0, currency: "USD")
 
-      # Investment accounts (USD + GBP)
-      @vanguard_401k     = family.accounts.create!(accountable: Investment.new, name: "Vanguard 401(k)", balance: 0, currency: "USD")
-      @schwab_brokerage  = family.accounts.create!(accountable: Investment.new, name: "Charles Schwab Brokerage", balance: 0, currency: "USD")
-      @fidelity_roth_ira = family.accounts.create!(accountable: Investment.new, name: "Fidelity Roth IRA", balance: 0, currency: "USD")
-      @hsa_investment    = family.accounts.create!(accountable: Investment.new, name: "Fidelity HSA Investment", balance: 0, currency: "USD")
-      @uk_isa           = family.accounts.create!(accountable: Investment.new, name: "Vanguard UK ISA", balance: 0, currency: "GBP")
+    # Crypto (USD)
+    @coinbase_usdc = family.accounts.create!(accountable: Crypto.new, name: "Coinbase USDC", balance: 0, currency: "USD")
 
-      # Property (USD)
-      @home = family.accounts.create!(accountable: Property.new, name: "Primary Residence", balance: 0, currency: "USD")
+    # Loans / Liabilities (USD)
+    @mortgage      = family.accounts.create!(accountable: Loan.new, name: "Home Mortgage", balance: 0, currency: "USD")
+    @car_loan      = family.accounts.create!(accountable: Loan.new, name: "Car Loan", balance: 0, currency: "USD")
+    @student_loan  = family.accounts.create!(accountable: Loan.new, name: "Student Loan", balance: 0, currency: "USD")
 
-      # Vehicles (USD)
-      @honda_accord = family.accounts.create!(accountable: Vehicle.new, name: "2016 Honda Accord", balance: 0, currency: "USD")
-      @tesla_model3 = family.accounts.create!(accountable: Vehicle.new, name: "2021 Tesla Model 3", balance: 0, currency: "USD")
+    @personal_loc  = family.accounts.create!(accountable: OtherLiability.new, name: "Personal Line of Credit", balance: 0, currency: "USD")
 
-      # Crypto (USD)
-      @coinbase_usdc = family.accounts.create!(accountable: Crypto.new, name: "Coinbase USDC", balance: 0, currency: "USD")
+    # Other asset (USD)
+    @jewelry = family.accounts.create!(accountable: OtherAsset.new, name: "Jewelry Collection", balance: 0, currency: "USD")
+  end
 
-      # Loans / Liabilities (USD)
-      @mortgage      = family.accounts.create!(accountable: Loan.new, name: "Home Mortgage", balance: 0, currency: "USD")
-      @car_loan      = family.accounts.create!(accountable: Loan.new, name: "Car Loan", balance: 0, currency: "USD")
-      @student_loan  = family.accounts.create!(accountable: Loan.new, name: "Student Loan", balance: 0, currency: "USD")
+  def create_realistic_transactions!(family)
+    load_securities!
 
-      @personal_loc  = family.accounts.create!(accountable: OtherLiability.new, name: "Personal Line of Credit", balance: 0, currency: "USD")
+    puts "   📈 Generating salary history (12 years)..."
+    generate_salary_history!
 
-      # Other asset (USD)
-      @jewelry = family.accounts.create!(accountable: OtherAsset.new, name: "Jewelry Collection", balance: 0, currency: "USD")
-    end
+    puts "   🏠 Generating housing transactions..."
+    generate_housing_transactions!
 
-    def create_realistic_transactions!(family)
-      load_securities!
+    puts "   🍕 Generating food & dining transactions..."
+    generate_food_transactions!
 
-      puts "   📈 Generating salary history (12 years)..."
-      generate_salary_history!
+    puts "   🚗 Generating transportation transactions..."
+    generate_transportation_transactions!
 
-      puts "   🏠 Generating housing transactions..."
-      generate_housing_transactions!
+    puts "   🎬 Generating entertainment transactions..."
+    generate_entertainment_transactions!
 
-      puts "   🍕 Generating food & dining transactions..."
-      generate_food_transactions!
+    puts "   🛒 Generating shopping transactions..."
+    generate_shopping_transactions!
 
-      puts "   🚗 Generating transportation transactions..."
-      generate_transportation_transactions!
+    puts "   ⚕️ Generating healthcare transactions..."
+    generate_healthcare_transactions!
 
-      puts "   🎬 Generating entertainment transactions..."
-      generate_entertainment_transactions!
+    puts "   ✈️ Generating travel transactions..."
+    generate_travel_transactions!
 
-      puts "   🛒 Generating shopping transactions..."
-      generate_shopping_transactions!
+    puts "   💅 Generating personal care transactions..."
+    generate_personal_care_transactions!
 
-      puts "   ⚕️ Generating healthcare transactions..."
-      generate_healthcare_transactions!
+    puts "   💰 Generating investment transactions..."
+    generate_investment_transactions!
 
-      puts "   ✈️ Generating travel transactions..."
-      generate_travel_transactions!
+    puts "   🏡 Generating major purchases..."
+    generate_major_purchases!
 
-      puts "   💅 Generating personal care transactions..."
-      generate_personal_care_transactions!
+    puts "   💳 Generating transfers and payments..."
+    generate_transfers_and_payments!
 
-      puts "   💰 Generating investment transactions..."
-      generate_investment_transactions!
+    puts "   🏦 Generating loan payments..."
+    generate_loan_payments!
 
-      puts "   🏡 Generating major purchases..."
-      generate_major_purchases!
+    puts "   🧾 Generating regular expense baseline..."
+    generate_regular_expenses!
 
-      puts "   💳 Generating transfers and payments..."
-      generate_transfers_and_payments!
+    puts "   🗄️  Generating legacy historical data..."
+    generate_legacy_transactions!
 
-      puts "   🏦 Generating loan payments..."
-      generate_loan_payments!
+    puts "   🔒 Generating crypto & misc asset transactions..."
+    generate_crypto_and_misc_assets!
 
-      puts "   🧾 Generating regular expense baseline..."
-      generate_regular_expenses!
+    puts "   ✅ Reconciling balances to target snapshot..."
+    reconcile_balances!(family)
 
-      puts "   🗄️  Generating legacy historical data..."
-      generate_legacy_transactions!
+    puts "   📊 Generated approximately #{Entry.joins(:account).where(accounts: { family_id: family.id }).count} transactions"
 
-      puts "   🔒 Generating crypto & misc asset transactions..."
-      generate_crypto_and_misc_assets!
+    puts "🔄 Final sync to calculate adjusted balances..."
+    sync_family_accounts!(family)
+  end
 
-      puts "   ✅ Reconciling balances to target snapshot..."
-      reconcile_balances!(family)
+  # Auto-fill current-month budget based on recent spending averages
+  def generate_budget_auto_fill!(family)
+    current_month   = Date.current.beginning_of_month
+    analysis_start  = (current_month - 3.months).beginning_of_month
+    analysis_period = analysis_start..(current_month - 1.day)
 
-      puts "   📊 Generated approximately #{Entry.joins(:account).where(accounts: { family_id: family.id }).count} transactions"
+    # Fetch expense transactions in the analysis period
+    txns = Entry.joins("INNER JOIN transactions ON transactions.id = entries.entryable_id")
+                .joins("INNER JOIN categories ON categories.id = transactions.category_id")
+                .where(entries: { entryable_type: "Transaction", date: analysis_period })
+                .where(categories: { classification: "expense" })
 
-      puts "🔄 Final sync to calculate adjusted balances..."
-      sync_family_accounts!(family)
-    end
+    spend_per_cat = txns.group("categories.id").sum("entries.amount")
 
-    # Auto-fill current-month budget based on recent spending averages
-    def generate_budget_auto_fill!(family)
-      current_month   = Date.current.beginning_of_month
-      analysis_start  = (current_month - 3.months).beginning_of_month
-      analysis_period = analysis_start..(current_month - 1.day)
+    budget = family.budgets.where(start_date: current_month).first_or_initialize
+    budget.update!(
+      end_date: current_month.end_of_month,
+      currency: "USD",
+      budgeted_spending: spend_per_cat.values.sum / 3.0, # placeholder, refine below
+      expected_income: 0 # Could compute similarly if desired
+    )
 
-      # Fetch expense transactions in the analysis period
-      txns = Entry.joins("INNER JOIN transactions ON transactions.id = entries.entryable_id")
-                  .joins("INNER JOIN categories ON categories.id = transactions.category_id")
-                  .where(entries: { entryable_type: "Transaction", date: analysis_period })
-                  .where(categories: { classification: "expense" })
-
-      spend_per_cat = txns.group("categories.id").sum("entries.amount")
-
-      budget = family.budgets.where(start_date: current_month).first_or_initialize
-      budget.update!(
-        end_date: current_month.end_of_month,
-        currency: "USD",
-        budgeted_spending: spend_per_cat.values.sum / 3.0, # placeholder, refine below
-        expected_income: 0 # Could compute similarly if desired
-      )
-
-      spend_per_cat.each do |cat_id, total|
-        avg = total / 3.0
-        rounded = ((avg / 25.0).round) * 25
-        category = Category.find(cat_id)
-        budget.budget_categories.find_or_create_by!(category: category) do |bc|
-          bc.budgeted_spending = rounded
-          bc.currency = "USD"
-        end
-      end
-
-      # Update aggregate budgeted_spending to sum of categories
-      budget.update!(budgeted_spending: budget.budget_categories.sum(:budgeted_spending))
-    end
-
-    # Helper method to get weighted random date (favoring recent years)
-    def weighted_random_date
-      # Focus on last 3 years for transaction generation
-      rand(3.years.ago.to_date..Date.current)
-    end
-
-    # Helper method to get random accounts for transactions
-    def random_checking_account
-      [@chase_checking, @ally_checking].sample
-    end
-
-    # ---------------------------------------------------------------------------
-    # Payroll system — 156 deterministic deposits (bi-weekly, six years)
-    # ---------------------------------------------------------------------------
-    def generate_salary_history!
-      deposit_amount = 8_500  # Increased from 4,200 to ~$200k annually
-      total_deposits = 78     # Reduced from 156 (only 3 years instead of 6)
-
-      # Find first Friday ≥ 3.years.ago so the cadence remains bi-weekly.
-      first_date = 3.years.ago.to_date
-      first_date += 1 until first_date.friday?
-
-      total_deposits.times do |i|
-        date = first_date + (14 * i)
-        break if date > Date.current # safety
-
-        amount = -jitter(deposit_amount, 0.02).round # negative inflow per conventions
-        create_transaction!(@chase_checking, amount, "Acme Corp Payroll", @salary_cat, date)
-
-        # 10 % automated savings transfer to Marcus Savings same day
-        savings_amount = (-amount * 0.10).round
-        create_transfer!(@chase_checking, @marcus_savings, savings_amount, "Auto-Save 10% of Paycheck", date)
-      end
-
-      # Add freelance income to help balance expenses
-      15.times do
-        date = weighted_random_date
-        amount = -rand(1500..4000)  # Negative for income
-        create_transaction!(@chase_checking, amount, "Freelance Project", @freelance_cat, date)
-      end
-
-      # Add quarterly investment dividends
-      (3.years.ago.to_date..Date.current).each do |date|
-        next unless date.day == 15 && [3, 6, 9, 12].include?(date.month) # Quarterly
-        dividend_amount = -rand(800..1500)  # Negative for income
-        create_transaction!(@chase_checking, dividend_amount, "Investment Dividends", @investment_income_cat, date)
-      end
-
-      # Add more regular freelance income to maintain positive checking balance
-      40.times do  # Increased from 15
-        date = weighted_random_date
-        amount = -rand(800..2500)  # More frequent, smaller freelance income
-        create_transaction!(@chase_checking, amount, "Freelance Payment", @freelance_cat, date)
-      end
-
-      # Add side income streams
-      25.times do
-        date = weighted_random_date
-        amount = -rand(200..800)
-        income_types = ["Cash Tips", "Selling Items", "Refund", "Rebate", "Gift Card Cash Out"]
-        create_transaction!(@chase_checking, amount, income_types.sample, @freelance_cat, date)
+    spend_per_cat.each do |cat_id, total|
+      avg = total / 3.0
+      rounded = ((avg / 25.0).round) * 25
+      category = Category.find(cat_id)
+      budget.budget_categories.find_or_create_by!(category: category) do |bc|
+        bc.budgeted_spending = rounded
+        bc.currency = "USD"
       end
     end
 
-    def generate_housing_transactions!
-      start_date = 3.years.ago.to_date  # Reduced from 12 years
-      base_rent = 2500 # Higher starting amount for higher income family
+    # Update aggregate budgeted_spending to sum of categories
+    budget.update!(budgeted_spending: budget.budget_categories.sum(:budgeted_spending))
+  end
 
-      # Monthly rent/mortgage payments
+  # Helper method to get weighted random date (favoring recent years)
+  def weighted_random_date
+    # Focus on last 3 years for transaction generation
+    rand(3.years.ago.to_date..Date.current)
+  end
+
+  # Helper method to get random accounts for transactions
+  def random_checking_account
+    [@chase_checking, @ally_checking].sample
+  end
+
+  # ---------------------------------------------------------------------------
+  # Payroll system — 156 deterministic deposits (bi-weekly, six years)
+  # ---------------------------------------------------------------------------
+  def generate_salary_history!
+    deposit_amount = 8_500  # Increased from 4,200 to ~$200k annually
+    total_deposits = 78     # Reduced from 156 (only 3 years instead of 6)
+
+    # Find first Friday ≥ 3.years.ago so the cadence remains bi-weekly.
+    first_date = 3.years.ago.to_date
+    first_date += 1 until first_date.friday?
+
+    total_deposits.times do |i|
+      date = first_date + (14 * i)
+      break if date > Date.current # safety
+
+      amount = -jitter(deposit_amount, 0.02).round # negative inflow per conventions
+      create_transaction!(@chase_checking, amount, "Acme Corp Payroll", @salary_cat, date)
+
+      # 10 % automated savings transfer to Marcus Savings same day
+      savings_amount = (-amount * 0.10).round
+      create_transfer!(@chase_checking, @marcus_savings, savings_amount, "Auto-Save 10% of Paycheck", date)
+    end
+
+    # Add freelance income to help balance expenses
+    15.times do
+      date = weighted_random_date
+      amount = -rand(1500..4000)  # Negative for income
+      create_transaction!(@chase_checking, amount, "Freelance Project", @freelance_cat, date)
+    end
+
+    # Add quarterly investment dividends
+    (3.years.ago.to_date..Date.current).each do |date|
+      next unless date.day == 15 && [3, 6, 9, 12].include?(date.month) # Quarterly
+      dividend_amount = -rand(800..1500)  # Negative for income
+      create_transaction!(@chase_checking, dividend_amount, "Investment Dividends", @investment_income_cat, date)
+    end
+
+    # Add more regular freelance income to maintain positive checking balance
+    40.times do  # Increased from 15
+      date = weighted_random_date
+      amount = -rand(800..2500)  # More frequent, smaller freelance income
+      create_transaction!(@chase_checking, amount, "Freelance Payment", @freelance_cat, date)
+    end
+
+    # Add side income streams
+    25.times do
+      date = weighted_random_date
+      amount = -rand(200..800)
+      income_types = ["Cash Tips", "Selling Items", "Refund", "Rebate", "Gift Card Cash Out"]
+      create_transaction!(@chase_checking, amount, income_types.sample, @freelance_cat, date)
+    end
+  end
+
+  def generate_housing_transactions!
+    start_date = 3.years.ago.to_date  # Reduced from 12 years
+    base_rent = 2500 # Higher starting amount for higher income family
+
+    # Monthly rent/mortgage payments
+    (start_date..Date.current).each do |date|
+      next unless date.day == 1 # First of month
+
+      # Mortgage payment from checking account (positive expense)
+      create_transaction!(@chase_checking, 2800, "Mortgage Payment", @rent_cat, date)
+      # Principal payment reduces mortgage debt (negative transaction)
+      principal_payment = 800 # ~$800 goes to principal
+      create_transaction!(@mortgage, -principal_payment, "Principal Payment", nil, date)
+    end
+
+    # Monthly utilities (reduced frequency)
+    utilities = [
+      { name: "ConEd Electric", range: 150..300 },
+      { name: "Verizon Internet", range: 85..105 },
+      { name: "Water & Sewer", range: 60..90 },
+      { name: "Gas Bill", range: 80..220 }
+    ]
+
+    utilities.each do |utility|
       (start_date..Date.current).each do |date|
-        next unless date.day == 1 # First of month
+        next unless date.day.between?(5, 15) && rand < 0.9 # Monthly with higher frequency
+        amount = rand(utility[:range])
+        create_transaction!(@chase_checking, amount, utility[:name], @utilities_cat, date)
+      end
+    end
+  end
 
-        # Mortgage payment from checking account (positive expense)
-        create_transaction!(@chase_checking, 2800, "Mortgage Payment", @rent_cat, date)
-        # Principal payment reduces mortgage debt (negative transaction)
-        principal_payment = 800 # ~$800 goes to principal
-        create_transaction!(@mortgage, -principal_payment, "Principal Payment", nil, date)
+  def generate_food_transactions!
+    # Weekly groceries (increased volume but kept amounts reasonable)
+    120.times do  # Increased from 60
+      date = weighted_random_date
+      amount = rand(60..180) # Reduced max from 220
+      stores = ["Whole Foods", "Trader Joe's", "Safeway", "Stop & Shop", "Fresh Market"]
+      create_transaction!(@chase_checking, amount, "#{stores.sample} Market", @groceries_cat, date)
+    end
+
+    # Restaurant dining (increased volume)
+    100.times do  # Increased from 50
+      date = weighted_random_date
+      amount = rand(25..65) # Reduced max from 80
+      restaurants = ["Pizza Corner", "Sushi Place", "Italian Kitchen", "Mexican Grill", "Greek Taverna"]
+      create_transaction!(@chase_checking, amount, restaurants.sample, @restaurants_cat, date)
+    end
+
+    # Coffee & takeout (increased volume)
+    80.times do  # Increased from 40
+      date = weighted_random_date
+      amount = rand(8..20) # Reduced from 10-25
+      places = ["Local Coffee", "Dunkin'", "Corner Deli", "Food Truck"]
+      create_transaction!(@chase_checking, amount, places.sample, @coffee_cat, date)
+    end
+  end
+
+  def generate_transportation_transactions!
+    # Gas stations (checking account only)
+    60.times do
+      date = weighted_random_date
+      amount = rand(35..75)
+      stations = ["Shell", "Exxon", "BP", "Chevron", "Mobil", "Sunoco"]
+      create_transaction!(@chase_checking, amount, "#{stations.sample} Gas", @gas_cat, date)
+    end
+
+    # Car payment (monthly for 6 years)
+    car_payment_start = 6.years.ago.to_date
+    car_payment_end = 1.year.ago.to_date
+
+    (car_payment_start..car_payment_end).each do |date|
+      next unless date.day == 15 # 15th of month
+      create_transaction!(@chase_checking, 385, "Auto Loan Payment", @car_payment_cat, date)
+    end
+  end
+
+  def generate_entertainment_transactions!
+    # Monthly subscriptions (increased timeframe)
+    subscriptions = [
+      { name: "Netflix", amount: 15 },
+      { name: "Spotify Premium", amount: 12 },
+      { name: "Disney+", amount: 8 },
+      { name: "HBO Max", amount: 16 },
+      { name: "Amazon Prime", amount: 14 }
+    ]
+
+    subscriptions.each do |sub|
+      (3.years.ago.to_date..Date.current).each do |date| # Reduced from 12 years
+        next unless date.day == rand(1..28) && rand < 0.9 # Higher frequency for active subscriptions
+        create_transaction!(@chase_checking, sub[:amount], sub[:name], @entertainment_cat, date)
+      end
+    end
+
+    # Random entertainment (increased volume)
+    60.times do  # Increased from 25
+      date = weighted_random_date
+      amount = rand(15..60) # Reduced from 20-80
+      activities = ["Movie Theater", "Sports Game", "Museum", "Comedy Club", "Bowling", "Mini Golf", "Arcade"]
+      create_transaction!(@chase_checking, amount, activities.sample, @entertainment_cat, date)
+    end
+  end
+
+  def generate_shopping_transactions!
+    # Online shopping (increased volume)
+    80.times do  # Increased from 40
+      date = weighted_random_date
+      amount = rand(30..90) # Reduced max from 120
+      stores = ["Target.com", "Walmart", "Costco"]
+      create_transaction!(@chase_checking, amount, "#{stores.sample} Purchase", @shopping_cat, date)
+    end
+
+    # In-store shopping (increased volume)
+    60.times do  # Increased from 25
+      date = weighted_random_date
+      amount = rand(35..80) # Reduced max from 100
+      stores = ["Target", "REI", "Barnes & Noble", "GameStop"]
+      create_transaction!(@chase_checking, amount, stores.sample, @shopping_cat, date)
+    end
+  end
+
+  def generate_healthcare_transactions!
+    # Doctor visits (increased volume)
+    45.times do  # Increased from 25
+      date = weighted_random_date
+      amount = rand(150..350) # Reduced from 180-450
+      providers = ["Dr. Smith", "Dr. Johnson", "Dr. Williams", "Specialist Visit", "Urgent Care"]
+      create_transaction!(@chase_checking, amount, providers.sample, @healthcare_cat, date)
+    end
+
+    # Pharmacy (increased volume)
+    80.times do  # Increased from 40
+      date = weighted_random_date
+      amount = rand(12..65) # Reduced from 15-85
+      pharmacies = ["CVS Pharmacy", "Walgreens", "Rite Aid", "Local Pharmacy"]
+      create_transaction!(@chase_checking, amount, pharmacies.sample, @healthcare_cat, date)
+    end
+  end
+
+  def generate_travel_transactions!
+    # Major vacations (reduced count - premium travel handled in credit card cycles)
+    8.times do
+      date = weighted_random_date
+
+      # Smaller local trips from checking
+      hotel_amount = rand(200..500)
+      hotels = ["Local Hotel", "B&B", "Nearby Resort"]
+      if rand < 0.3 && date > 3.years.ago.to_date # Some EUR transactions
+        create_transaction!(@eu_checking, hotel_amount, hotels.sample, @travel_cat, date)
+      else
+        create_transaction!(@chase_checking, hotel_amount, hotels.sample, @travel_cat, date)
       end
 
-      # Monthly utilities (reduced frequency)
-      utilities = [
-        { name: "ConEd Electric", range: 150..300 },
-        { name: "Verizon Internet", range: 85..105 },
-        { name: "Water & Sewer", range: 60..90 },
-        { name: "Gas Bill", range: 80..220 }
+      # Domestic flights (smaller amounts)
+      flight_amount = rand(200..400)
+      create_transaction!(@chase_checking, flight_amount, "Domestic Flight", @travel_cat, date + rand(1..5).days)
+
+      # Local activities
+      activity_amount = rand(50..150)
+      activities = ["Local Tour", "Museum Tickets", "Activity Pass"]
+      create_transaction!(@chase_checking, activity_amount, activities.sample, @travel_cat, date + rand(1..7).days)
+    end
+  end
+
+  def generate_personal_care_transactions!
+    # Gym membership
+    (12.years.ago.to_date..Date.current).each do |date|
+      next unless date.day == 1 && rand < 0.8 # Monthly
+      create_transaction!(@chase_checking, 45, "Gym Membership", @personal_care_cat, date)
+    end
+
+    # Beauty/grooming (checking account only)
+    40.times do
+      date = weighted_random_date
+      amount = rand(25..80)
+      services = ["Hair Salon", "Barber Shop", "Nail Salon"]
+      create_transaction!(@chase_checking, amount, services.sample, @personal_care_cat, date)
+    end
+  end
+
+  def generate_investment_transactions!
+    security = Security.first || Security.create!(ticker: "VTI", name: "Vanguard Total Stock Market ETF", country_code: "US")
+
+    generate_401k_trades!(security)
+    generate_brokerage_trades!(security)
+    generate_roth_trades!(security)
+    generate_uk_isa_trades!(security)
+  end
+
+  # ---------------------------------------------------- 401k (180 trades) --
+  def generate_401k_trades!(security)
+    payroll_dates = collect_payroll_dates.first(90) # 90 paydays ⇒ 180 trades
+
+    payroll_dates.each do |date|
+      # Employee contribution $1 200
+      create_trade_for(@vanguard_401k, security, 1_200, date, "401k Employee")
+
+      # Employer match $300
+      create_trade_for(@vanguard_401k, security, 300, date, "401k Employer Match")
+    end
+  end
+
+  # -------------------------------------------- Brokerage (144 trades) -----
+  def generate_brokerage_trades!(security)
+    date_cursor = 36.months.ago.beginning_of_month
+    while date_cursor <= Date.current
+      4.times do |i|
+        trade_date = date_cursor + i * 7.days # roughly spread within month
+        create_trade_for(@schwab_brokerage, security, rand(400..1_000), trade_date, "Brokerage Purchase")
+      end
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+  end
+
+  # ----------------------------------------------- Roth IRA (108 trades) ---
+  def generate_roth_trades!(security)
+    date_cursor = 36.months.ago.beginning_of_month
+    while date_cursor <= Date.current
+      # Split $500 monthly across 3 staggered trades
+      3.times do |i|
+        trade_date = date_cursor + i * 10.days
+        create_trade_for(@fidelity_roth_ira, security, (500 / 3.0), trade_date, "Roth IRA Contribution")
+      end
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+  end
+
+  # ------------------------------------------------- UK ISA (108 trades) ----
+  def generate_uk_isa_trades!(security)
+    date_cursor = 36.months.ago.beginning_of_month
+    while date_cursor <= Date.current
+      3.times do |i|
+        trade_date = date_cursor + i * 10.days
+        create_trade_for(@uk_isa, security, (400 / 3.0), trade_date, "ISA Investment", price_range: 60..150)
+      end
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+  end
+
+  # --------------------------- Helpers for investment trade generation -----
+  def collect_payroll_dates
+    dates = []
+    d = 36.months.ago.to_date
+    d += 1 until d.friday?
+    while d <= Date.current
+      dates << d if d.cweek.even?
+      d += 14 # next bi-weekly
+    end
+    dates
+  end
+
+  def create_trade_for(account, security, investment_amount, date, memo, price_range: 80..200)
+    price = rand(price_range)
+    qty   = (investment_amount.to_f / price).round(2)
+    create_investment_transaction!(account, security, qty, price, date, memo)
+  end
+
+  def generate_major_purchases!
+    # Home purchase (5 years ago) - only record the down payment, not full value
+    # Property value will be set by valuation in reconcile_balances!
+    home_date = 5.years.ago.to_date
+    create_transaction!(@chase_checking, 70_000, "Home Down Payment", @housing_cat, home_date)
+    create_transaction!(@mortgage, 320_000, "Mortgage Principal", nil, home_date) # Initial mortgage debt
+
+    # Initial account funding (realistic amounts)
+    create_transaction!(@chase_checking, -5_000, "Initial Deposit", @salary_cat, 12.years.ago.to_date)
+    create_transaction!(@ally_checking, -2_000, "Initial Deposit", @salary_cat, 12.years.ago.to_date)
+    create_transaction!(@marcus_savings, -10_000, "Initial Savings", @salary_cat, 12.years.ago.to_date)
+    create_transaction!(@eu_checking, -5_000, "EUR Account Opening", nil, 4.years.ago.to_date)
+
+    # Car purchases (realistic amounts)
+    create_transaction!(@chase_checking, 3_000, "Car Down Payment", @transportation_cat, 6.years.ago.to_date)
+    create_transaction!(@chase_checking, 2_500, "Second Car Down Payment", @transportation_cat, 8.years.ago.to_date)
+
+    # Major but realistic expenses
+    create_transaction!(@chase_checking, 8_000, "Kitchen Renovation", @utilities_cat, 2.years.ago.to_date)
+    create_transaction!(@chase_checking, 5_000, "Bathroom Remodel", @utilities_cat, 1.year.ago.to_date)
+    create_transaction!(@chase_checking, 12_000, "Roof Replacement", @utilities_cat, 3.years.ago.to_date)
+    create_transaction!(@chase_checking, 8_000, "Family Emergency", @healthcare_cat, 4.years.ago.to_date)
+    create_transaction!(@chase_checking, 15_000, "Wedding Expenses", @entertainment_cat, 9.years.ago.to_date)
+  end
+
+  def generate_transfers_and_payments!
+    generate_credit_card_cycles!
+
+    generate_monthly_ally_transfers!
+    generate_quarterly_fx_transfers!
+    generate_additional_savings_transfers!
+  end
+
+  # Additional savings transfers to improve income/expense balance
+  def generate_additional_savings_transfers!
+    # Monthly extra savings transfers
+    (3.years.ago.to_date..Date.current).each do |date|
+      next unless date.day == 15 && rand < 0.7 # Semi-monthly savings
+      amount = rand(500..1500)
+      create_transfer!(@chase_checking, @marcus_savings, amount, "Extra Savings Transfer", date)
+    end
+
+    # Quarterly HSA contributions
+    (3.years.ago.to_date..Date.current).each do |date|
+      next unless date.day == 1 && [1, 4, 7, 10].include?(date.month) # Quarterly
+      amount = rand(1000..2000)
+      create_transfer!(@chase_checking, @hsa_investment, amount, "HSA Contribution", date)
+    end
+
+    # Occasional windfalls (tax refunds, bonuses, etc.)
+    8.times do
+      date = weighted_random_date
+      amount = rand(2000..8000)
+      create_transaction!(@chase_checking, -amount, "Tax Refund/Bonus", @salary_cat, date)
+    end
+
+    # CRITICAL: Regular transfers FROM savings TO checking to maintain positive balance
+    # This is realistic - people move money from savings to checking regularly
+    (3.years.ago.to_date..Date.current).each do |date|
+      next unless date.day == rand(20..28) && rand < 0.8 # Monthly transfers from savings
+      amount = rand(2000..5000)
+      create_transfer!(@marcus_savings, @chase_checking, amount, "Transfer from Savings", date)
+    end
+
+    # Weekly smaller transfers from savings for cash flow
+    (3.years.ago.to_date..Date.current).each do |date|
+      next unless date.wday == 1 && rand < 0.4 # Some Mondays
+      amount = rand(500..1200)
+      create_transfer!(@marcus_savings, @chase_checking, amount, "Weekly Cash Flow", date)
+    end
+  end
+
+  # $300 from Chase Checking to Ally Checking on the first business day of each
+  # month for the past 36 months.
+  def generate_monthly_ally_transfers!
+    date_cursor = 36.months.ago.beginning_of_month
+    while date_cursor <= Date.current
+      transfer_date = first_business_day(date_cursor)
+      create_transfer!(@chase_checking, @ally_checking, 300, "Monthly Ally Transfer", transfer_date)
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+  end
+
+  # Quarterly $2 000 FX transfer from Chase Checking to EUR account
+  def generate_quarterly_fx_transfers!
+    date_cursor = 36.months.ago.beginning_of_quarter
+    while date_cursor <= Date.current
+      transfer_date = date_cursor + 2.days # arbitrary within quarter start
+      create_transfer!(@chase_checking, @eu_checking, 2_000, "Quarterly FX Transfer", transfer_date)
+      date_cursor = date_cursor.next_quarter.beginning_of_quarter
+    end
+  end
+
+  # Returns the first weekday (Mon-Fri) of the month containing +date+.
+  def first_business_day(date)
+    d = date.beginning_of_month
+    d += 1.day while d.saturday? || d.sunday?
+    d
+  end
+
+  def generate_credit_card_cycles!
+    # REDUCED: 30-45 charges per month across both cards for 36 months (≈1,400 total)
+    # This is still significant but more realistic than 80-120/month
+    # Pay 90-95 % of new balance 5 days post-cycle; final balances should
+    # be ~$2 500 (Amex) and ~$4 200 (Sapphire).
+
+    start_date = 36.months.ago.beginning_of_month
+    end_date   = Date.current.end_of_month
+
+    amex_balance      = 0
+    sapphire_balance  = 0
+
+    charges_this_run  = 0
+    payments_this_run = 0
+
+    date_cursor = start_date
+    while date_cursor <= end_date
+      # --- Charge generation (REDUCED FOR BALANCE) -------------------------
+      month_charge_target = rand(30..45)  # Reduced from 80-120 to 30-45
+      # Split roughly evenly but add a little variance.
+      amex_count     = (month_charge_target * rand(0.45..0.55)).to_i
+      sapphire_count = month_charge_target - amex_count
+
+      amex_total     = generate_credit_card_charges(@amex_gold,     date_cursor, amex_count)
+      sapphire_total = generate_credit_card_charges(@chase_sapphire, date_cursor, sapphire_count)
+
+      amex_balance     += amex_total
+      sapphire_balance += sapphire_total
+
+      charges_this_run += (amex_count + sapphire_count)
+
+      # --- Monthly payments (5 days after month end) ------------------------
+      payment_date = (date_cursor.end_of_month + 5.days)
+
+      if amex_total.positive?
+        amex_payment = (amex_total * rand(0.90..0.95)).round
+        create_transfer!(@chase_checking, @amex_gold, amex_payment, "Amex Payment", payment_date)
+        amex_balance -= amex_payment
+        payments_this_run += 1
+      end
+
+      if sapphire_total.positive?
+        sapphire_payment = (sapphire_total * rand(0.90..0.95)).round
+        create_transfer!(@chase_checking, @chase_sapphire, sapphire_payment, "Sapphire Payment", payment_date)
+        sapphire_balance -= sapphire_payment
+        payments_this_run += 1
+      end
+
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+
+    # -----------------------------------------------------------------------
+    # Re-balance to hit target ending balances (tolerance ±$250)
+    # -----------------------------------------------------------------------
+    target_amex     = 2_500
+    target_sapphire = 4_200
+
+    diff_amex     = amex_balance - target_amex
+    diff_sapphire = sapphire_balance - target_sapphire
+
+    if diff_amex.abs > 250
+      adjust_payment = diff_amex.positive? ? diff_amex : 0
+      create_transfer!(@chase_checking, @amex_gold, adjust_payment, "Amex Balance Adjust", Date.current)
+      amex_balance -= adjust_payment
+    end
+
+    if diff_sapphire.abs > 250
+      adjust_payment = diff_sapphire.positive? ? diff_sapphire : 0
+      create_transfer!(@chase_checking, @chase_sapphire, adjust_payment, "Sapphire Balance Adjust", Date.current)
+      sapphire_balance -= adjust_payment
+    end
+
+    puts "   💳 Charges generated: #{charges_this_run} | Payments: #{payments_this_run}"
+    puts "   💳 Final Amex balance: ~$#{amex_balance} | target ~$#{target_amex}"
+    puts "   💳 Final Sapphire balance: ~$#{sapphire_balance} | target ~$#{target_sapphire}"
+  end
+
+  # Generate exactly +count+ charges on +account+ within the month of +base_date+.
+  # Returns total charge amount.
+  def generate_credit_card_charges(account, base_date, count)
+    total = 0
+
+    count.times do
+      charge_date = base_date + rand(0..27).days
+
+      amount = rand(15..80) # Reduced from 25..150 due to higher frequency
+      # bias amounts to achieve reasonable monthly totals
+      amount = jitter(amount, 0.15).round
+
+      merchant = if account == @amex_gold
+        pick(%w[WholeFoods Starbucks UberEats Netflix LocalBistro AirBnB])
+      else
+        pick(["Delta Airlines", "Hilton Hotels", "Expedia", "Apple", "BestBuy", "Amazon"])
+      end
+
+      create_transaction!(account, amount, merchant, random_expense_category, charge_date)
+      total += amount
+    end
+
+    total
+  end
+
+  def random_expense_category
+    [@food_cat, @entertainment_cat, @shopping_cat, @travel_cat, @transportation_cat].sample
+  end
+
+  def create_transaction!(account, amount, name, category, date)
+    # For credit cards (liabilities), positive amounts = charges (increase debt)
+    # For checking accounts (assets), positive amounts = expenses (decrease balance)
+    # The amount is already signed correctly by the caller
+    account.entries.create!(
+      entryable: Transaction.new(category: category),
+      amount: amount,
+      name: name,
+      currency: account.currency,
+      date: date
+    )
+  end
+
+  def create_investment_transaction!(account, security, qty, price, date, name)
+    account.entries.create!(
+      entryable: Trade.new(security: security, qty: qty, price: price, currency: account.currency),
+      amount: -(qty * price),
+      name: name,
+      currency: account.currency,
+      date: date
+    )
+  end
+
+  def create_transfer!(from_account, to_account, amount, name, date)
+    outflow = from_account.entries.create!(
+      entryable: Transaction.new,
+      amount: amount,
+      name: name,
+      currency: from_account.currency,
+      date: date
+    )
+    inflow = to_account.entries.create!(
+      entryable: Transaction.new,
+      amount: -amount,
+      name: name,
+      currency: to_account.currency,
+      date: date
+    )
+    Transfer.create!(inflow_transaction: inflow.entryable, outflow_transaction: outflow.entryable)
+  end
+
+  def load_securities!
+    return if Security.exists?
+
+    Security.create!([
+      { ticker: "VTI", name: "Vanguard Total Stock Market ETF", country_code: "US" },
+      { ticker: "VXUS", name: "Vanguard Total International Stock ETF", country_code: "US" },
+      { ticker: "BND", name: "Vanguard Total Bond Market ETF", country_code: "US" }
+    ])
+  end
+
+  def sync_family_accounts!(family)
+    family.accounts.each do |account|
+      sync = Sync.create!(syncable: account)
+      sync.perform
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  #                         Deterministic helper methods
+  # ---------------------------------------------------------------------------
+
+  # Deterministically walk through the elements of +array+, returning the next
+  # element each time it is called with the *same* array instance.
+  #
+  # Example:
+  #   colours = %w[red green blue]
+  #   4.times.map { pick(colours) } #=> ["red", "green", "blue", "red"]
+  def pick(array)
+    @pick_indices ||= Hash.new(0)
+    idx = @pick_indices[array.object_id]
+    @pick_indices[array.object_id] += 1
+    array[idx % array.length]
+  end
+
+  # Adds a small random variation (±pct, default 3%) to +num+.  Useful for
+  # making otherwise deterministic amounts look more natural while retaining
+  # overall reproducibility via the seeded RNG.
+  def jitter(num, pct = 0.03)
+    variation = num * pct * (rand * 2 - 1) # rand(-pct..pct)
+    (num + variation).round(2)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Loan payments (Task 8)
+  # ---------------------------------------------------------------------------
+  def generate_loan_payments!
+    date_cursor = 36.months.ago.beginning_of_month
+    while date_cursor <= Date.current
+      payment_date = first_business_day(date_cursor)
+
+      # Mortgage
+      make_loan_payment!(
+        principal_account: @mortgage,
+        principal_amount: 600,
+        interest_amount: 1_100,
+        interest_category: @housing_cat,
+        date: payment_date,
+        memo: "Mortgage Payment"
+      )
+
+      # Student loan
+      make_loan_payment!(
+        principal_account: @student_loan,
+        principal_amount: 350,
+        interest_amount: 100,
+        interest_category: @interest_cat,
+        date: payment_date,
+        memo: "Student Loan Payment"
+      )
+
+      # Car loan – assume 300 principal / 130 interest
+      make_loan_payment!(
+        principal_account: @car_loan,
+        principal_amount: 300,
+        interest_amount: 130,
+        interest_category: @transportation_cat,
+        date: payment_date,
+        memo: "Auto Loan Payment"
+      )
+
+      date_cursor = date_cursor.next_month.beginning_of_month
+    end
+  end
+
+  def make_loan_payment!(principal_account:, principal_amount:, interest_amount:, interest_category:, date:, memo:)
+    # Principal portion – transfer from checking to loan account
+    create_transfer!(@chase_checking, principal_account, principal_amount, memo, date)
+
+    # Interest portion – expense from checking
+    create_transaction!(@chase_checking, interest_amount, "#{memo} Interest", interest_category, date)
+  end
+
+  # Generate additional baseline expenses to reach 8k-12k transaction target
+  def generate_regular_expenses!
+    expense_generators = [
+      ->(date) { create_transaction!(@chase_checking, jitter(rand(150..220), 0.05).round, pick(["ConEd Electric", "National Grid", "Gas & Power"]), @utilities_cat, date) },
+      ->(date) { create_transaction!(@chase_checking, jitter(rand(10..20), 0.1).round, pick(["Spotify", "Netflix", "Hulu", "Apple One"]), @entertainment_cat, date) },
+      ->(date) { create_transaction!(@chase_checking, jitter(rand(45..90), 0.1).round, pick(["Whole Foods", "Trader Joe's", "Safeway"])+" Market", @groceries_cat, date) },
+      ->(date) { create_transaction!(@chase_checking, jitter(rand(25..50), 0.1).round, pick(["Shell Gas", "BP Gas", "Exxon"]), @gas_cat, date) },
+      ->(date) { create_transaction!(@chase_checking, jitter(rand(15..40), 0.1).round, pick(["Movie Streaming", "Book Purchase", "Mobile Game"]), @entertainment_cat, date) }
+    ]
+
+    desired = 600  # Increased from 300 to help reach 8k
+    current = Entry.joins(:account).where(accounts: { id: [@chase_checking.id] }, entryable_type: "Transaction").count
+    to_create = [desired - current, 0].max
+
+    to_create.times do
+      date = weighted_random_date
+      expense_generators.sample.call(date)
+    end
+
+    # Add high-volume, low-impact transactions to reach 8k minimum
+    generate_micro_transactions!
+  end
+
+  # Generate many small transactions to reach volume target
+  def generate_micro_transactions!
+    # ATM withdrawals and fees (reduced)
+    120.times do  # Reduced from 200
+      date = weighted_random_date
+      amount = rand(20..60)
+      create_transaction!(@chase_checking, amount, "ATM Withdrawal", @misc_cat, date)
+      # Small ATM fee
+      create_transaction!(@chase_checking, rand(2..4), "ATM Fee", @misc_cat, date)
+    end
+
+    # Small convenience store purchases (reduced)
+    200.times do  # Reduced from 300
+      date = weighted_random_date
+      amount = rand(3..15)
+      stores = ["7-Eleven", "Wawa", "Circle K", "Quick Stop", "Corner Store"]
+      create_transaction!(@chase_checking, amount, stores.sample, @shopping_cat, date)
+    end
+
+    # Small digital purchases (reduced)
+    120.times do  # Reduced from 200
+      date = weighted_random_date
+      amount = rand(1..10)
+      items = ["App Store", "Google Play", "iTunes", "Steam", "Kindle Book"]
+      create_transaction!(@chase_checking, amount, items.sample, @entertainment_cat, date)
+    end
+
+    # Parking meters and tolls (reduced)
+    100.times do  # Reduced from 150
+      date = weighted_random_date
+      amount = rand(2..8)
+      create_transaction!(@chase_checking, amount, pick(["Parking Meter", "Bridge Toll", "Tunnel Toll"]), @transportation_cat, date)
+    end
+
+    # Small cash transactions (reduced)
+    150.times do  # Reduced from 250
+      date = weighted_random_date
+      amount = rand(5..25)
+      vendors = ["Food Truck", "Farmer's Market", "Street Vendor", "Tip", "Donation"]
+      create_transaction!(@chase_checking, amount, vendors.sample, @misc_cat, date)
+    end
+
+    # Vending machine purchases (reduced)
+    60.times do  # Reduced from 100
+      date = weighted_random_date
+      amount = rand(1..5)
+      create_transaction!(@chase_checking, amount, "Vending Machine", @shopping_cat, date)
+    end
+
+    # Public transportation (reduced)
+    120.times do  # Reduced from 180
+      date = weighted_random_date
+      amount = rand(2..8)
+      transit = ["Metro Card", "Bus Fare", "Train Ticket", "Uber/Lyft"]
+      create_transaction!(@chase_checking, amount, transit.sample, @transportation_cat, date)
+    end
+
+    # Additional small transactions to ensure we reach 8k minimum (reduced)
+    400.times do  # Reduced from 600
+      date = weighted_random_date
+      amount = rand(1..12)
+      merchants = [
+        "Newsstand", "Coffee Cart", "Tip Jar", "Donation Box", "Laundromat",
+        "Car Wash", "Redbox", "PayPhone", "Photo Booth", "Arcade Game",
+        "Postage", "Newspaper", "Lottery Ticket", "Gumball Machine", "Ice Cream Truck"
       ]
-
-      utilities.each do |utility|
-        (start_date..Date.current).each do |date|
-          next unless date.day.between?(5, 15) && rand < 0.9 # Monthly with higher frequency
-          amount = rand(utility[:range])
-          create_transaction!(@chase_checking, amount, utility[:name], @utilities_cat, date)
-        end
-      end
+      create_transaction!(@chase_checking, amount, merchants.sample, @misc_cat, date)
     end
 
-    def generate_food_transactions!
-      # Weekly groceries (increased volume but kept amounts reasonable)
-      120.times do  # Increased from 60
-        date = weighted_random_date
-        amount = rand(60..180) # Reduced max from 220
-        stores = ["Whole Foods", "Trader Joe's", "Safeway", "Stop & Shop", "Fresh Market"]
-        create_transaction!(@chase_checking, amount, "#{stores.sample} Market", @groceries_cat, date)
-      end
-
-      # Restaurant dining (increased volume)
-      100.times do  # Increased from 50
-        date = weighted_random_date
-        amount = rand(25..65) # Reduced max from 80
-        restaurants = ["Pizza Corner", "Sushi Place", "Italian Kitchen", "Mexican Grill", "Greek Taverna"]
-        create_transaction!(@chase_checking, amount, restaurants.sample, @restaurants_cat, date)
-      end
-
-      # Coffee & takeout (increased volume)
-      80.times do  # Increased from 40
-        date = weighted_random_date
-        amount = rand(8..20) # Reduced from 10-25
-        places = ["Local Coffee", "Dunkin'", "Corner Deli", "Food Truck"]
-        create_transaction!(@chase_checking, amount, places.sample, @coffee_cat, date)
-      end
-    end
-
-    def generate_transportation_transactions!
-      # Gas stations (checking account only)
-      60.times do
-        date = weighted_random_date
-        amount = rand(35..75)
-        stations = ["Shell", "Exxon", "BP", "Chevron", "Mobil", "Sunoco"]
-        create_transaction!(@chase_checking, amount, "#{stations.sample} Gas", @gas_cat, date)
-      end
-
-      # Car payment (monthly for 6 years)
-      car_payment_start = 6.years.ago.to_date
-      car_payment_end = 1.year.ago.to_date
-
-      (car_payment_start..car_payment_end).each do |date|
-        next unless date.day == 15 # 15th of month
-        create_transaction!(@chase_checking, 385, "Auto Loan Payment", @car_payment_cat, date)
-      end
-    end
-
-    def generate_entertainment_transactions!
-      # Monthly subscriptions (increased timeframe)
-      subscriptions = [
-        { name: "Netflix", amount: 15 },
-        { name: "Spotify Premium", amount: 12 },
-        { name: "Disney+", amount: 8 },
-        { name: "HBO Max", amount: 16 },
-        { name: "Amazon Prime", amount: 14 }
+    # Extra small transactions to ensure 8k+ volume
+    500.times do
+      date = weighted_random_date
+      amount = rand(1..8)
+      tiny_merchants = [
+        "Candy Machine", "Sticker Machine", "Penny Scale", "Charity Donation",
+        "Busker Tip", "Church Offering", "Lemonade Stand", "Girl Scout Cookies",
+        "Raffle Ticket", "Bake Sale", "Car Wash Tip", "Street Performer"
       ]
+      create_transaction!(@chase_checking, amount, tiny_merchants.sample, @misc_cat, date)
+    end
+  end
 
-      subscriptions.each do |sub|
-        (3.years.ago.to_date..Date.current).each do |date| # Reduced from 12 years
-          next unless date.day == rand(1..28) && rand < 0.9 # Higher frequency for active subscriptions
-          create_transaction!(@chase_checking, sub[:amount], sub[:name], @entertainment_cat, date)
-        end
+  # ---------------------------------------------------------------------------
+  # Legacy historical transactions (Task 11)
+  # ---------------------------------------------------------------------------
+  def generate_legacy_transactions!
+    # Small recent legacy transactions (3-6 years ago)
+    count = rand(40..60)  # Increased from 20-30
+    count.times do
+      years_ago = rand(3..6)
+      date = years_ago.years.ago.to_date - rand(0..364).days
+
+      base_amount = rand(12..45)  # Reduced from 15-60
+      discount    = (1 - 0.02 * [years_ago - 3, 0].max)
+      amount      = (base_amount * discount).round
+
+      account = [@chase_checking, @ally_checking].sample
+      category = pick([@groceries_cat, @utilities_cat, @gas_cat, @restaurants_cat, @shopping_cat])
+
+      merchant = case category
+      when @groceries_cat then pick(%w[Walmart Kroger Safeway]) + " Market"
+      when @utilities_cat then pick(["Local Electric", "City Water", "Gas Co."])
+      when @gas_cat then pick(%w[Shell Exxon BP])
+      when @restaurants_cat then pick(["Diner", "Burger Grill", "Pizza Place"])
+      else pick(["General Store", "Department Shop", "Outlet"])
       end
 
-      # Random entertainment (increased volume)
-      60.times do  # Increased from 25
-        date = weighted_random_date
-        amount = rand(15..60) # Reduced from 20-80
-        activities = ["Movie Theater", "Sports Game", "Museum", "Comedy Club", "Bowling", "Mini Golf", "Arcade"]
-        create_transaction!(@chase_checking, amount, activities.sample, @entertainment_cat, date)
-      end
+      create_transaction!(account, amount, merchant, category, date)
     end
 
-    def generate_shopping_transactions!
-      # Online shopping (increased volume)
-      80.times do  # Increased from 40
-        date = weighted_random_date
-        amount = rand(30..90) # Reduced max from 120
-        stores = ["Target.com", "Walmart", "Costco"]
-        create_transaction!(@chase_checking, amount, "#{stores.sample} Purchase", @shopping_cat, date)
+    # Very old transactions (7-15 years ago) - just scattered outliers
+    count = rand(25..40)  # Increased from 15-25
+    count.times do
+      years_ago = rand(7..15)
+      date = years_ago.years.ago.to_date - rand(0..364).days
+
+      base_amount = rand(8..30)  # Reduced from 10-40
+      discount    = (1 - 0.03 * [years_ago - 7, 0].max)  # More discount for very old
+      amount      = (base_amount * discount).round.clamp(5, 25)  # Reduced max from 35
+
+      account = @chase_checking  # Just use main checking for simplicity
+      category = pick([@groceries_cat, @gas_cat, @restaurants_cat])
+
+      merchant = case category
+      when @groceries_cat then pick(%w[Walmart Kroger]) + " Market"
+      when @gas_cat then pick(%w[Shell Exxon])
+      else pick(["Old Diner", "Local Restaurant"])
       end
 
-      # In-store shopping (increased volume)
-      60.times do  # Increased from 25
-        date = weighted_random_date
-        amount = rand(35..80) # Reduced max from 100
-        stores = ["Target", "REI", "Barnes & Noble", "GameStop"]
-        create_transaction!(@chase_checking, amount, stores.sample, @shopping_cat, date)
-      end
+      create_transaction!(account, amount, "#{merchant} (#{years_ago}y ago)", category, date)
     end
 
-    def generate_healthcare_transactions!
-      # Doctor visits (increased volume)
-      45.times do  # Increased from 25
-        date = weighted_random_date
-        amount = rand(150..350) # Reduced from 180-450
-        providers = ["Dr. Smith", "Dr. Johnson", "Dr. Williams", "Specialist Visit", "Urgent Care"]
-        create_transaction!(@chase_checking, amount, providers.sample, @healthcare_cat, date)
-      end
+    # Additional small transactions to reach 8k minimum if needed
+    additional_needed = [400, 0].max  # Increased from 200
+    additional_needed.times do
+      years_ago = rand(4..12)
+      date = years_ago.years.ago.to_date - rand(0..364).days
+      amount = rand(6..20)  # Reduced from 8-25
 
-      # Pharmacy (increased volume)
-      80.times do  # Increased from 40
-        date = weighted_random_date
-        amount = rand(12..65) # Reduced from 15-85
-        pharmacies = ["CVS Pharmacy", "Walgreens", "Rite Aid", "Local Pharmacy"]
-        create_transaction!(@chase_checking, amount, pharmacies.sample, @healthcare_cat, date)
-      end
+      account = [@chase_checking, @ally_checking].sample
+      category = pick([@groceries_cat, @gas_cat, @utilities_cat])
+
+      merchant = "Legacy #{pick(%w[Store Gas Electric])}"
+      create_transaction!(account, amount, merchant, category, date)
     end
-
-    def generate_travel_transactions!
-      # Major vacations (reduced count - premium travel handled in credit card cycles)
-      8.times do
-        date = weighted_random_date
-
-        # Smaller local trips from checking
-        hotel_amount = rand(200..500)
-        hotels = ["Local Hotel", "B&B", "Nearby Resort"]
-        if rand < 0.3 && date > 3.years.ago.to_date # Some EUR transactions
-          create_transaction!(@eu_checking, hotel_amount, hotels.sample, @travel_cat, date)
-        else
-          create_transaction!(@chase_checking, hotel_amount, hotels.sample, @travel_cat, date)
-        end
-
-        # Domestic flights (smaller amounts)
-        flight_amount = rand(200..400)
-        create_transaction!(@chase_checking, flight_amount, "Domestic Flight", @travel_cat, date + rand(1..5).days)
-
-        # Local activities
-        activity_amount = rand(50..150)
-        activities = ["Local Tour", "Museum Tickets", "Activity Pass"]
-        create_transaction!(@chase_checking, activity_amount, activities.sample, @travel_cat, date + rand(1..7).days)
-      end
-    end
-
-    def generate_personal_care_transactions!
-      # Gym membership
-      (12.years.ago.to_date..Date.current).each do |date|
-        next unless date.day == 1 && rand < 0.8 # Monthly
-        create_transaction!(@chase_checking, 45, "Gym Membership", @personal_care_cat, date)
-      end
-
-      # Beauty/grooming (checking account only)
-      40.times do
-        date = weighted_random_date
-        amount = rand(25..80)
-        services = ["Hair Salon", "Barber Shop", "Nail Salon"]
-        create_transaction!(@chase_checking, amount, services.sample, @personal_care_cat, date)
-      end
-    end
-
-    def generate_investment_transactions!
-      security = Security.first || Security.create!(ticker: "VTI", name: "Vanguard Total Stock Market ETF", country_code: "US")
-
-      generate_401k_trades!(security)
-      generate_brokerage_trades!(security)
-      generate_roth_trades!(security)
-      generate_uk_isa_trades!(security)
-    end
-
-    # ---------------------------------------------------- 401k (180 trades) --
-    def generate_401k_trades!(security)
-      payroll_dates = collect_payroll_dates.first(90) # 90 paydays ⇒ 180 trades
-
-      payroll_dates.each do |date|
-        # Employee contribution $1 200
-        create_trade_for(@vanguard_401k, security, 1_200, date, "401k Employee")
-
-        # Employer match $300
-        create_trade_for(@vanguard_401k, security, 300, date, "401k Employer Match")
-      end
-    end
-
-    # -------------------------------------------- Brokerage (144 trades) -----
-    def generate_brokerage_trades!(security)
-      date_cursor = 36.months.ago.beginning_of_month
-      while date_cursor <= Date.current
-        4.times do |i|
-          trade_date = date_cursor + i * 7.days # roughly spread within month
-          create_trade_for(@schwab_brokerage, security, rand(400..1_000), trade_date, "Brokerage Purchase")
-        end
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-    end
-
-    # ----------------------------------------------- Roth IRA (108 trades) ---
-    def generate_roth_trades!(security)
-      date_cursor = 36.months.ago.beginning_of_month
-      while date_cursor <= Date.current
-        # Split $500 monthly across 3 staggered trades
-        3.times do |i|
-          trade_date = date_cursor + i * 10.days
-          create_trade_for(@fidelity_roth_ira, security, (500 / 3.0), trade_date, "Roth IRA Contribution")
-        end
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-    end
-
-    # ------------------------------------------------- UK ISA (108 trades) ----
-    def generate_uk_isa_trades!(security)
-      date_cursor = 36.months.ago.beginning_of_month
-      while date_cursor <= Date.current
-        3.times do |i|
-          trade_date = date_cursor + i * 10.days
-          create_trade_for(@uk_isa, security, (400 / 3.0), trade_date, "ISA Investment", price_range: 60..150)
-        end
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-    end
-
-    # --------------------------- Helpers for investment trade generation -----
-    def collect_payroll_dates
-      dates = []
-      d = 36.months.ago.to_date
-      d += 1 until d.friday?
-      while d <= Date.current
-        dates << d if d.cweek.even?
-        d += 14 # next bi-weekly
-      end
-      dates
-    end
-
-    def create_trade_for(account, security, investment_amount, date, memo, price_range: 80..200)
-      price = rand(price_range)
-      qty   = (investment_amount.to_f / price).round(2)
-      create_investment_transaction!(account, security, qty, price, date, memo)
-    end
-
-    def generate_major_purchases!
-      # Home purchase (5 years ago) - only record the down payment, not full value
-      # Property value will be set by valuation in reconcile_balances!
-      home_date = 5.years.ago.to_date
-      create_transaction!(@chase_checking, 70_000, "Home Down Payment", @housing_cat, home_date)
-      create_transaction!(@mortgage, 320_000, "Mortgage Principal", nil, home_date) # Initial mortgage debt
-
-      # Initial account funding (realistic amounts)
-      create_transaction!(@chase_checking, -5_000, "Initial Deposit", @salary_cat, 12.years.ago.to_date)
-      create_transaction!(@ally_checking, -2_000, "Initial Deposit", @salary_cat, 12.years.ago.to_date)
-      create_transaction!(@marcus_savings, -10_000, "Initial Savings", @salary_cat, 12.years.ago.to_date)
-      create_transaction!(@eu_checking, -5_000, "EUR Account Opening", nil, 4.years.ago.to_date)
-
-      # Car purchases (realistic amounts)
-      create_transaction!(@chase_checking, 3_000, "Car Down Payment", @transportation_cat, 6.years.ago.to_date)
-      create_transaction!(@chase_checking, 2_500, "Second Car Down Payment", @transportation_cat, 8.years.ago.to_date)
-
-      # Major but realistic expenses
-      create_transaction!(@chase_checking, 8_000, "Kitchen Renovation", @utilities_cat, 2.years.ago.to_date)
-      create_transaction!(@chase_checking, 5_000, "Bathroom Remodel", @utilities_cat, 1.year.ago.to_date)
-      create_transaction!(@chase_checking, 12_000, "Roof Replacement", @utilities_cat, 3.years.ago.to_date)
-      create_transaction!(@chase_checking, 8_000, "Family Emergency", @healthcare_cat, 4.years.ago.to_date)
-      create_transaction!(@chase_checking, 15_000, "Wedding Expenses", @entertainment_cat, 9.years.ago.to_date)
-    end
-
-    def generate_transfers_and_payments!
-      generate_credit_card_cycles!
-
-      generate_monthly_ally_transfers!
-      generate_quarterly_fx_transfers!
-      generate_additional_savings_transfers!
-    end
-
-    # Additional savings transfers to improve income/expense balance
-    def generate_additional_savings_transfers!
-      # Monthly extra savings transfers
-      (3.years.ago.to_date..Date.current).each do |date|
-        next unless date.day == 15 && rand < 0.7 # Semi-monthly savings
-        amount = rand(500..1500)
-        create_transfer!(@chase_checking, @marcus_savings, amount, "Extra Savings Transfer", date)
-      end
-
-      # Quarterly HSA contributions
-      (3.years.ago.to_date..Date.current).each do |date|
-        next unless date.day == 1 && [1, 4, 7, 10].include?(date.month) # Quarterly
-        amount = rand(1000..2000)
-        create_transfer!(@chase_checking, @hsa_investment, amount, "HSA Contribution", date)
-      end
-
-      # Occasional windfalls (tax refunds, bonuses, etc.)
-      8.times do
-        date = weighted_random_date
-        amount = rand(2000..8000)
-        create_transaction!(@chase_checking, -amount, "Tax Refund/Bonus", @salary_cat, date)
-      end
-
-      # CRITICAL: Regular transfers FROM savings TO checking to maintain positive balance
-      # This is realistic - people move money from savings to checking regularly
-      (3.years.ago.to_date..Date.current).each do |date|
-        next unless date.day == rand(20..28) && rand < 0.8 # Monthly transfers from savings
-        amount = rand(2000..5000)
-        create_transfer!(@marcus_savings, @chase_checking, amount, "Transfer from Savings", date)
-      end
-
-      # Weekly smaller transfers from savings for cash flow
-      (3.years.ago.to_date..Date.current).each do |date|
-        next unless date.wday == 1 && rand < 0.4 # Some Mondays
-        amount = rand(500..1200)
-        create_transfer!(@marcus_savings, @chase_checking, amount, "Weekly Cash Flow", date)
-      end
-    end
-
-    # $300 from Chase Checking to Ally Checking on the first business day of each
-    # month for the past 36 months.
-    def generate_monthly_ally_transfers!
-      date_cursor = 36.months.ago.beginning_of_month
-      while date_cursor <= Date.current
-        transfer_date = first_business_day(date_cursor)
-        create_transfer!(@chase_checking, @ally_checking, 300, "Monthly Ally Transfer", transfer_date)
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-    end
-
-    # Quarterly $2 000 FX transfer from Chase Checking to EUR account
-    def generate_quarterly_fx_transfers!
-      date_cursor = 36.months.ago.beginning_of_quarter
-      while date_cursor <= Date.current
-        transfer_date = date_cursor + 2.days # arbitrary within quarter start
-        create_transfer!(@chase_checking, @eu_checking, 2_000, "Quarterly FX Transfer", transfer_date)
-        date_cursor = date_cursor.next_quarter.beginning_of_quarter
-      end
-    end
-
-    # Returns the first weekday (Mon-Fri) of the month containing +date+.
-    def first_business_day(date)
-      d = date.beginning_of_month
-      d += 1.day while d.saturday? || d.sunday?
-      d
-    end
-
-    def generate_credit_card_cycles!
-      # REDUCED: 30-45 charges per month across both cards for 36 months (≈1,400 total)
-      # This is still significant but more realistic than 80-120/month
-      # Pay 90-95 % of new balance 5 days post-cycle; final balances should
-      # be ~$2 500 (Amex) and ~$4 200 (Sapphire).
-
-      start_date = 36.months.ago.beginning_of_month
-      end_date   = Date.current.end_of_month
-
-      amex_balance      = 0
-      sapphire_balance  = 0
-
-      charges_this_run  = 0
-      payments_this_run = 0
-
-      date_cursor = start_date
-      while date_cursor <= end_date
-        # --- Charge generation (REDUCED FOR BALANCE) -------------------------
-        month_charge_target = rand(30..45)  # Reduced from 80-120 to 30-45
-        # Split roughly evenly but add a little variance.
-        amex_count     = (month_charge_target * rand(0.45..0.55)).to_i
-        sapphire_count = month_charge_target - amex_count
-
-        amex_total     = generate_credit_card_charges(@amex_gold,     date_cursor, amex_count)
-        sapphire_total = generate_credit_card_charges(@chase_sapphire, date_cursor, sapphire_count)
-
-        amex_balance     += amex_total
-        sapphire_balance += sapphire_total
-
-        charges_this_run += (amex_count + sapphire_count)
-
-        # --- Monthly payments (5 days after month end) ------------------------
-        payment_date = (date_cursor.end_of_month + 5.days)
-
-        if amex_total.positive?
-          amex_payment = (amex_total * rand(0.90..0.95)).round
-          create_transfer!(@chase_checking, @amex_gold, amex_payment, "Amex Payment", payment_date)
-          amex_balance -= amex_payment
-          payments_this_run += 1
-        end
-
-        if sapphire_total.positive?
-          sapphire_payment = (sapphire_total * rand(0.90..0.95)).round
-          create_transfer!(@chase_checking, @chase_sapphire, sapphire_payment, "Sapphire Payment", payment_date)
-          sapphire_balance -= sapphire_payment
-          payments_this_run += 1
-        end
-
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-
-      # -----------------------------------------------------------------------
-      # Re-balance to hit target ending balances (tolerance ±$250)
-      # -----------------------------------------------------------------------
-      target_amex     = 2_500
-      target_sapphire = 4_200
-
-      diff_amex     = amex_balance - target_amex
-      diff_sapphire = sapphire_balance - target_sapphire
-
-      if diff_amex.abs > 250
-        adjust_payment = diff_amex.positive? ? diff_amex : 0
-        create_transfer!(@chase_checking, @amex_gold, adjust_payment, "Amex Balance Adjust", Date.current)
-        amex_balance -= adjust_payment
-      end
-
-      if diff_sapphire.abs > 250
-        adjust_payment = diff_sapphire.positive? ? diff_sapphire : 0
-        create_transfer!(@chase_checking, @chase_sapphire, adjust_payment, "Sapphire Balance Adjust", Date.current)
-        sapphire_balance -= adjust_payment
-      end
-
-      puts "   💳 Charges generated: #{charges_this_run} | Payments: #{payments_this_run}"
-      puts "   💳 Final Amex balance: ~$#{amex_balance} | target ~$#{target_amex}"
-      puts "   💳 Final Sapphire balance: ~$#{sapphire_balance} | target ~$#{target_sapphire}"
-    end
-
-    # Generate exactly +count+ charges on +account+ within the month of +base_date+.
-    # Returns total charge amount.
-    def generate_credit_card_charges(account, base_date, count)
-      total = 0
-
-      count.times do
-        charge_date = base_date + rand(0..27).days
-
-        amount = rand(15..80) # Reduced from 25..150 due to higher frequency
-        # bias amounts to achieve reasonable monthly totals
-        amount = jitter(amount, 0.15).round
-
-        merchant = if account == @amex_gold
-          pick(%w[WholeFoods Starbucks UberEats Netflix LocalBistro AirBnB])
-        else
-          pick(["Delta Airlines", "Hilton Hotels", "Expedia", "Apple", "BestBuy", "Amazon"])
-        end
-
-        create_transaction!(account, amount, merchant, random_expense_category, charge_date)
-        total += amount
-      end
-
-      total
-    end
-
-    def random_expense_category
-      [@food_cat, @entertainment_cat, @shopping_cat, @travel_cat, @transportation_cat].sample
-    end
-
-    def create_transaction!(account, amount, name, category, date)
-      # For credit cards (liabilities), positive amounts = charges (increase debt)
-      # For checking accounts (assets), positive amounts = expenses (decrease balance)
-      # The amount is already signed correctly by the caller
-      account.entries.create!(
-        entryable: Transaction.new(category: category),
-        amount: amount,
-        name: name,
-        currency: account.currency,
-        date: date
-      )
-    end
-
-    def create_investment_transaction!(account, security, qty, price, date, name)
-      account.entries.create!(
-        entryable: Trade.new(security: security, qty: qty, price: price, currency: account.currency),
-        amount: -(qty * price),
-        name: name,
-        currency: account.currency,
-        date: date
-      )
-    end
-
-    def create_transfer!(from_account, to_account, amount, name, date)
-      outflow = from_account.entries.create!(
-        entryable: Transaction.new,
-        amount: amount,
-        name: name,
-        currency: from_account.currency,
-        date: date
-      )
-      inflow = to_account.entries.create!(
-        entryable: Transaction.new,
-        amount: -amount,
-        name: name,
-        currency: to_account.currency,
-        date: date
-      )
-      Transfer.create!(inflow_transaction: inflow.entryable, outflow_transaction: outflow.entryable)
-    end
-
-    def load_securities!
-      return if Security.exists?
-
-      Security.create!([
-        { ticker: "VTI", name: "Vanguard Total Stock Market ETF", country_code: "US" },
-        { ticker: "VXUS", name: "Vanguard Total International Stock ETF", country_code: "US" },
-        { ticker: "BND", name: "Vanguard Total Bond Market ETF", country_code: "US" }
-      ])
-    end
-
-    def sync_family_accounts!(family)
-      family.accounts.each do |account|
-        sync = Sync.create!(syncable: account)
-        sync.perform
-      end
-    end
-
-    # ---------------------------------------------------------------------------
-    #                         Deterministic helper methods
-    # ---------------------------------------------------------------------------
-
-    # Deterministically walk through the elements of +array+, returning the next
-    # element each time it is called with the *same* array instance.
-    #
-    # Example:
-    #   colours = %w[red green blue]
-    #   4.times.map { pick(colours) } #=> ["red", "green", "blue", "red"]
-    def pick(array)
-      @pick_indices ||= Hash.new(0)
-      idx = @pick_indices[array.object_id]
-      @pick_indices[array.object_id] += 1
-      array[idx % array.length]
-    end
-
-    # Adds a small random variation (±pct, default 3%) to +num+.  Useful for
-    # making otherwise deterministic amounts look more natural while retaining
-    # overall reproducibility via the seeded RNG.
-    def jitter(num, pct = 0.03)
-      variation = num * pct * (rand * 2 - 1) # rand(-pct..pct)
-      (num + variation).round(2)
-    end
-
-    # ---------------------------------------------------------------------------
-    # Loan payments (Task 8)
-    # ---------------------------------------------------------------------------
-    def generate_loan_payments!
-      date_cursor = 36.months.ago.beginning_of_month
-      while date_cursor <= Date.current
-        payment_date = first_business_day(date_cursor)
-
-        # Mortgage
-        make_loan_payment!(
-          principal_account: @mortgage,
-          principal_amount: 600,
-          interest_amount: 1_100,
-          interest_category: @housing_cat,
-          date: payment_date,
-          memo: "Mortgage Payment"
-        )
-
-        # Student loan
-        make_loan_payment!(
-          principal_account: @student_loan,
-          principal_amount: 350,
-          interest_amount: 100,
-          interest_category: @interest_cat,
-          date: payment_date,
-          memo: "Student Loan Payment"
-        )
-
-        # Car loan – assume 300 principal / 130 interest
-        make_loan_payment!(
-          principal_account: @car_loan,
-          principal_amount: 300,
-          interest_amount: 130,
-          interest_category: @transportation_cat,
-          date: payment_date,
-          memo: "Auto Loan Payment"
-        )
-
-        date_cursor = date_cursor.next_month.beginning_of_month
-      end
-    end
-
-    def make_loan_payment!(principal_account:, principal_amount:, interest_amount:, interest_category:, date:, memo:)
-      # Principal portion – transfer from checking to loan account
-      create_transfer!(@chase_checking, principal_account, principal_amount, memo, date)
-
-      # Interest portion – expense from checking
-      create_transaction!(@chase_checking, interest_amount, "#{memo} Interest", interest_category, date)
-    end
-
-    # Generate additional baseline expenses to reach 8k-12k transaction target
-    def generate_regular_expenses!
-      expense_generators = [
-        ->(date) { create_transaction!(@chase_checking, jitter(rand(150..220), 0.05).round, pick(["ConEd Electric", "National Grid", "Gas & Power"]), @utilities_cat, date) },
-        ->(date) { create_transaction!(@chase_checking, jitter(rand(10..20), 0.1).round, pick(["Spotify", "Netflix", "Hulu", "Apple One"]), @entertainment_cat, date) },
-        ->(date) { create_transaction!(@chase_checking, jitter(rand(45..90), 0.1).round, pick(["Whole Foods", "Trader Joe's", "Safeway"])+" Market", @groceries_cat, date) },
-        ->(date) { create_transaction!(@chase_checking, jitter(rand(25..50), 0.1).round, pick(["Shell Gas", "BP Gas", "Exxon"]), @gas_cat, date) },
-        ->(date) { create_transaction!(@chase_checking, jitter(rand(15..40), 0.1).round, pick(["Movie Streaming", "Book Purchase", "Mobile Game"]), @entertainment_cat, date) }
-      ]
-
-      desired = 600  # Increased from 300 to help reach 8k
-      current = Entry.joins(:account).where(accounts: { id: [@chase_checking.id] }, entryable_type: "Transaction").count
-      to_create = [desired - current, 0].max
-
-      to_create.times do
-        date = weighted_random_date
-        expense_generators.sample.call(date)
-      end
-
-      # Add high-volume, low-impact transactions to reach 8k minimum
-      generate_micro_transactions!
-    end
-
-    # Generate many small transactions to reach volume target
-    def generate_micro_transactions!
-      # ATM withdrawals and fees (reduced)
-      120.times do  # Reduced from 200
-        date = weighted_random_date
-        amount = rand(20..60)
-        create_transaction!(@chase_checking, amount, "ATM Withdrawal", @misc_cat, date)
-        # Small ATM fee
-        create_transaction!(@chase_checking, rand(2..4), "ATM Fee", @misc_cat, date)
-      end
-
-      # Small convenience store purchases (reduced)
-      200.times do  # Reduced from 300
-        date = weighted_random_date
-        amount = rand(3..15)
-        stores = ["7-Eleven", "Wawa", "Circle K", "Quick Stop", "Corner Store"]
-        create_transaction!(@chase_checking, amount, stores.sample, @shopping_cat, date)
-      end
-
-      # Small digital purchases (reduced)
-      120.times do  # Reduced from 200
-        date = weighted_random_date
-        amount = rand(1..10)
-        items = ["App Store", "Google Play", "iTunes", "Steam", "Kindle Book"]
-        create_transaction!(@chase_checking, amount, items.sample, @entertainment_cat, date)
-      end
-
-      # Parking meters and tolls (reduced)
-      100.times do  # Reduced from 150
-        date = weighted_random_date
-        amount = rand(2..8)
-        create_transaction!(@chase_checking, amount, pick(["Parking Meter", "Bridge Toll", "Tunnel Toll"]), @transportation_cat, date)
-      end
-
-      # Small cash transactions (reduced)
-      150.times do  # Reduced from 250
-        date = weighted_random_date
-        amount = rand(5..25)
-        vendors = ["Food Truck", "Farmer's Market", "Street Vendor", "Tip", "Donation"]
-        create_transaction!(@chase_checking, amount, vendors.sample, @misc_cat, date)
-      end
-
-      # Vending machine purchases (reduced)
-      60.times do  # Reduced from 100
-        date = weighted_random_date
-        amount = rand(1..5)
-        create_transaction!(@chase_checking, amount, "Vending Machine", @shopping_cat, date)
-      end
-
-      # Public transportation (reduced)
-      120.times do  # Reduced from 180
-        date = weighted_random_date
-        amount = rand(2..8)
-        transit = ["Metro Card", "Bus Fare", "Train Ticket", "Uber/Lyft"]
-        create_transaction!(@chase_checking, amount, transit.sample, @transportation_cat, date)
-      end
-
-      # Additional small transactions to ensure we reach 8k minimum (reduced)
-      400.times do  # Reduced from 600
-        date = weighted_random_date
-        amount = rand(1..12)
-        merchants = [
-          "Newsstand", "Coffee Cart", "Tip Jar", "Donation Box", "Laundromat",
-          "Car Wash", "Redbox", "PayPhone", "Photo Booth", "Arcade Game",
-          "Postage", "Newspaper", "Lottery Ticket", "Gumball Machine", "Ice Cream Truck"
-        ]
-        create_transaction!(@chase_checking, amount, merchants.sample, @misc_cat, date)
-      end
-
-      # Extra small transactions to ensure 8k+ volume
-      500.times do
-        date = weighted_random_date
-        amount = rand(1..8)
-        tiny_merchants = [
-          "Candy Machine", "Sticker Machine", "Penny Scale", "Charity Donation",
-          "Busker Tip", "Church Offering", "Lemonade Stand", "Girl Scout Cookies",
-          "Raffle Ticket", "Bake Sale", "Car Wash Tip", "Street Performer"
-        ]
-        create_transaction!(@chase_checking, amount, tiny_merchants.sample, @misc_cat, date)
-      end
-    end
-
-    # ---------------------------------------------------------------------------
-    # Legacy historical transactions (Task 11)
-    # ---------------------------------------------------------------------------
-    def generate_legacy_transactions!
-      # Small recent legacy transactions (3-6 years ago)
-      count = rand(40..60)  # Increased from 20-30
-      count.times do
-        years_ago = rand(3..6)
-        date = years_ago.years.ago.to_date - rand(0..364).days
-
-        base_amount = rand(12..45)  # Reduced from 15-60
-        discount    = (1 - 0.02 * [years_ago - 3, 0].max)
-        amount      = (base_amount * discount).round
-
-        account = [@chase_checking, @ally_checking].sample
-        category = pick([@groceries_cat, @utilities_cat, @gas_cat, @restaurants_cat, @shopping_cat])
-
-        merchant = case category
-        when @groceries_cat then pick(%w[Walmart Kroger Safeway]) + " Market"
-        when @utilities_cat then pick(["Local Electric", "City Water", "Gas Co."])
-        when @gas_cat then pick(%w[Shell Exxon BP])
-        when @restaurants_cat then pick(["Diner", "Burger Grill", "Pizza Place"])
-        else pick(["General Store", "Department Shop", "Outlet"])
-        end
-
-        create_transaction!(account, amount, merchant, category, date)
-      end
-
-      # Very old transactions (7-15 years ago) - just scattered outliers
-      count = rand(25..40)  # Increased from 15-25
-      count.times do
-        years_ago = rand(7..15)
-        date = years_ago.years.ago.to_date - rand(0..364).days
-
-        base_amount = rand(8..30)  # Reduced from 10-40
-        discount    = (1 - 0.03 * [years_ago - 7, 0].max)  # More discount for very old
-        amount      = (base_amount * discount).round.clamp(5, 25)  # Reduced max from 35
-
-        account = @chase_checking  # Just use main checking for simplicity
-        category = pick([@groceries_cat, @gas_cat, @restaurants_cat])
-
-        merchant = case category
-        when @groceries_cat then pick(%w[Walmart Kroger]) + " Market"
-        when @gas_cat then pick(%w[Shell Exxon])
-        else pick(["Old Diner", "Local Restaurant"])
-        end
-
-        create_transaction!(account, amount, "#{merchant} (#{years_ago}y ago)", category, date)
-      end
-
-      # Additional small transactions to reach 8k minimum if needed
-      additional_needed = [400, 0].max  # Increased from 200
-      additional_needed.times do
-        years_ago = rand(4..12)
-        date = years_ago.years.ago.to_date - rand(0..364).days
-        amount = rand(6..20)  # Reduced from 8-25
-
-        account = [@chase_checking, @ally_checking].sample
-        category = pick([@groceries_cat, @gas_cat, @utilities_cat])
-
-        merchant = "Legacy #{pick(%w[Store Gas Electric])}"
-        create_transaction!(account, amount, merchant, category, date)
-      end
-    end
-
-    # ---------------------------------------------------------------------------
-    # Crypto & misc assets (Task 12)
-    # ---------------------------------------------------------------------------
-    def generate_crypto_and_misc_assets!
-      # One-time USDC deposit 18 months ago
-      deposit_date = 18.months.ago.to_date
-      create_transaction!(@coinbase_usdc, -3_500, "Initial USDC Deposit", nil, deposit_date)
-    end
-
-    # ---------------------------------------------------------------------------
-    # Balance Reconciliation (Task 14)
-    # ---------------------------------------------------------------------------
-    def reconcile_balances!(family)
-      # Use valuations only for property/vehicle accounts that should have specific values
-      # All other accounts should reach target balances through natural transaction flow
-
-      # Property valuations (these accounts are valued, not transaction-driven)
-      @home.entries.create!(
-        entryable: Valuation.new(kind: "current_anchor"),
-        amount: 350_000,
-        name: Valuation.build_current_anchor_name(@home.accountable_type),
-        currency: "USD",
-        date: Date.current
-      )
-
-      # Vehicle valuations (these depreciate over time)
-      @honda_accord.entries.create!(
-        entryable: Valuation.new(kind: "current_anchor"),
-        amount: 18_000,
-        name: Valuation.build_current_anchor_name(@honda_accord.accountable_type),
-        currency: "USD",
-        date: Date.current
-      )
-
-      @tesla_model3.entries.create!(
-        entryable: Valuation.new(kind: "current_anchor"),
-        amount: 4_500,
-        name: Valuation.build_current_anchor_name(@tesla_model3.accountable_type),
-        currency: "USD",
-        date: Date.current
-      )
-
-      @jewelry.entries.create!(
-        entryable: Valuation.new(kind: "reconciliation"),
-        amount: 2000,
-        name: Valuation.build_reconciliation_name(@jewelry.accountable_type),
-        currency: "USD",
-        date: 90.days.ago.to_date
-      )
-
-      @personal_loc.entries.create!(
-        entryable: Valuation.new(kind: "reconciliation"),
-        amount: 800,
-        name: Valuation.build_reconciliation_name(@personal_loc.accountable_type),
-        currency: "USD",
-        date: 120.days.ago.to_date
-      )
-
-      puts "   ✅ Set property and vehicle valuations"
-    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Crypto & misc assets (Task 12)
+  # ---------------------------------------------------------------------------
+  def generate_crypto_and_misc_assets!
+    # One-time USDC deposit 18 months ago
+    deposit_date = 18.months.ago.to_date
+    create_transaction!(@coinbase_usdc, -3_500, "Initial USDC Deposit", nil, deposit_date)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Balance Reconciliation (Task 14)
+  # ---------------------------------------------------------------------------
+  def reconcile_balances!(family)
+    # Use valuations only for property/vehicle accounts that should have specific values
+    # All other accounts should reach target balances through natural transaction flow
+
+    # Property valuations (these accounts are valued, not transaction-driven)
+    @home.entries.create!(
+      entryable: Valuation.new(kind: "current_anchor"),
+      amount: 350_000,
+      name: Valuation.build_current_anchor_name(@home.accountable_type),
+      currency: "USD",
+      date: Date.current
+    )
+
+    # Vehicle valuations (these depreciate over time)
+    @honda_accord.entries.create!(
+      entryable: Valuation.new(kind: "current_anchor"),
+      amount: 18_000,
+      name: Valuation.build_current_anchor_name(@honda_accord.accountable_type),
+      currency: "USD",
+      date: Date.current
+    )
+
+    @tesla_model3.entries.create!(
+      entryable: Valuation.new(kind: "current_anchor"),
+      amount: 4_500,
+      name: Valuation.build_current_anchor_name(@tesla_model3.accountable_type),
+      currency: "USD",
+      date: Date.current
+    )
+
+    @jewelry.entries.create!(
+      entryable: Valuation.new(kind: "reconciliation"),
+      amount: 2000,
+      name: Valuation.build_reconciliation_name(@jewelry.accountable_type),
+      currency: "USD",
+      date: 90.days.ago.to_date
+    )
+
+    @personal_loc.entries.create!(
+      entryable: Valuation.new(kind: "reconciliation"),
+      amount: 800,
+      name: Valuation.build_reconciliation_name(@personal_loc.accountable_type),
+      currency: "USD",
+      date: 120.days.ago.to_date
+    )
+
+    puts "   ✅ Set property and vehicle valuations"
+  end
 end

--- a/app/models/developer_message.rb
+++ b/app/models/developer_message.rb
@@ -4,7 +4,7 @@ class DeveloperMessage < Message
   end
 
   private
-    def broadcast?
-      chat.debug_mode?
-    end
+  def broadcast?
+    chat.debug_mode?
+  end
 end

--- a/app/models/exchange_rate/importer.rb
+++ b/app/models/exchange_rate/importer.rb
@@ -61,96 +61,96 @@ class ExchangeRate::Importer
   end
 
   private
-    attr_reader :exchange_rate_provider, :from, :to, :start_date, :end_date, :clear_cache
+  attr_reader :exchange_rate_provider, :from, :to, :start_date, :end_date, :clear_cache
 
-    def upsert_rows(rows)
-      batch_size = 200
+  def upsert_rows(rows)
+    batch_size = 200
 
-      total_upsert_count = 0
+    total_upsert_count = 0
 
-      rows.each_slice(batch_size) do |batch|
-        upserted_ids = ExchangeRate.upsert_all(
-          batch,
-          unique_by: %i[from_currency to_currency date],
-          returning: ["id"]
-        )
+    rows.each_slice(batch_size) do |batch|
+      upserted_ids = ExchangeRate.upsert_all(
+        batch,
+        unique_by: %i[from_currency to_currency date],
+        returning: ["id"]
+      )
 
-        total_upsert_count += upserted_ids.count
-      end
-
-      total_upsert_count
+      total_upsert_count += upserted_ids.count
     end
 
-    # Since provider may not return values on weekends and holidays, we grab the first rate from the provider that is on or before the start date
-    def start_rate_value
-      provider_rate_value = provider_rates.select { |date, _| date <= start_date }.max_by { |date, _| date }&.last
-      db_rate_value = db_rates[start_date]&.rate
-      provider_rate_value || db_rate_value
-    end
+    total_upsert_count
+  end
 
-    # No need to fetch/upsert rates for dates that we already have in the DB
-    def effective_start_date
-      return start_date if clear_cache
+  # Since provider may not return values on weekends and holidays, we grab the first rate from the provider that is on or before the start date
+  def start_rate_value
+    provider_rate_value = provider_rates.select { |date, _| date <= start_date }.max_by { |date, _| date }&.last
+    db_rate_value = db_rates[start_date]&.rate
+    provider_rate_value || db_rate_value
+  end
 
-      first_missing_date = nil
+  # No need to fetch/upsert rates for dates that we already have in the DB
+  def effective_start_date
+    return start_date if clear_cache
 
-      start_date.upto(end_date) do |date|
-        unless db_rates.key?(date)
-          first_missing_date = date
-          break
-        end
-      end
+    first_missing_date = nil
 
-      first_missing_date || end_date
-    end
-
-    def provider_rates
-      @provider_rates ||= begin
-        # Always fetch with a 5 day buffer to ensure we have a starting rate (for weekends and holidays)
-        provider_fetch_start_date = effective_start_date - 5.days
-
-        provider_response = exchange_rate_provider.fetch_exchange_rates(
-          from: from,
-          to: to,
-          start_date: provider_fetch_start_date,
-          end_date: end_date
-        )
-
-        if provider_response.success?
-          provider_response.data.index_by(&:date)
-        else
-          message = "#{exchange_rate_provider.class.name} could not fetch exchange rate pair from: #{from} to: #{to} between: #{effective_start_date} and: #{Date.current}.  Provider error: #{provider_response.error.message}"
-          Rails.logger.warn(message)
-          Sentry.capture_exception(MissingExchangeRateError.new(message), level: :warning)
-          {}
-        end
+    start_date.upto(end_date) do |date|
+      unless db_rates.key?(date)
+        first_missing_date = date
+        break
       end
     end
 
-    def all_rates_exist?
-      db_count == expected_count
-    end
+    first_missing_date || end_date
+  end
 
-    def expected_count
-      (start_date..end_date).count
-    end
+  def provider_rates
+    @provider_rates ||= begin
+      # Always fetch with a 5 day buffer to ensure we have a starting rate (for weekends and holidays)
+      provider_fetch_start_date = effective_start_date - 5.days
 
-    def db_count
-      db_rates.count
-    end
+      provider_response = exchange_rate_provider.fetch_exchange_rates(
+        from: from,
+        to: to,
+        start_date: provider_fetch_start_date,
+        end_date: end_date
+      )
 
-    def db_rates
-      @db_rates ||= ExchangeRate.where(from_currency: from, to_currency: to, date: start_date..end_date)
-                  .order(:date)
-                  .to_a
-                  .index_by(&:date)
+      if provider_response.success?
+        provider_response.data.index_by(&:date)
+      else
+        message = "#{exchange_rate_provider.class.name} could not fetch exchange rate pair from: #{from} to: #{to} between: #{effective_start_date} and: #{Date.current}.  Provider error: #{provider_response.error.message}"
+        Rails.logger.warn(message)
+        Sentry.capture_exception(MissingExchangeRateError.new(message), level: :warning)
+        {}
+      end
     end
+  end
 
-    # Normalizes an end date so that it never exceeds today's date in the
-    # America/New_York timezone. If the caller passes a future date we clamp
-    # it to today so that upstream provider calls remain valid and predictable.
-    def normalize_end_date(requested_end_date)
-      today_est = Date.current.in_time_zone("America/New_York").to_date
-      [requested_end_date, today_est].min
-    end
+  def all_rates_exist?
+    db_count == expected_count
+  end
+
+  def expected_count
+    (start_date..end_date).count
+  end
+
+  def db_count
+    db_rates.count
+  end
+
+  def db_rates
+    @db_rates ||= ExchangeRate.where(from_currency: from, to_currency: to, date: start_date..end_date)
+                .order(:date)
+                .to_a
+                .index_by(&:date)
+  end
+
+  # Normalizes an end date so that it never exceeds today's date in the
+  # America/New_York timezone. If the caller passes a future date we clamp
+  # it to today so that upstream provider calls remain valid and predictable.
+  def normalize_end_date(requested_end_date)
+    today_est = Date.current.in_time_zone("America/New_York").to_date
+    [requested_end_date, today_est].min
+  end
 end

--- a/app/models/family/auto_categorizer.rb
+++ b/app/models/family/auto_categorizer.rb
@@ -44,40 +44,40 @@ class Family::AutoCategorizer
   end
 
   private
-    attr_reader :family, :transaction_ids
+  attr_reader :family, :transaction_ids
 
-    # For now, OpenAI only, but this should work with any LLM concept provider
-    def llm_provider
-      Provider::Registry.get_provider(:openai)
-    end
+  # For now, OpenAI only, but this should work with any LLM concept provider
+  def llm_provider
+    Provider::Registry.get_provider(:openai)
+  end
 
-    def user_categories_input
-      family.categories.map do |category|
-        {
-          id: category.id,
-          name: category.name,
-          is_subcategory: category.subcategory?,
-          parent_id: category.parent_id,
-          classification: category.classification
-        }
-      end
+  def user_categories_input
+    family.categories.map do |category|
+      {
+        id: category.id,
+        name: category.name,
+        is_subcategory: category.subcategory?,
+        parent_id: category.parent_id,
+        classification: category.classification
+      }
     end
+  end
 
-    def transactions_input
-      scope.map do |transaction|
-        {
-          id: transaction.id,
-          amount: transaction.entry.amount.abs,
-          classification: transaction.entry.classification,
-          description: transaction.entry.name,
-          merchant: transaction.merchant&.name
-        }
-      end
+  def transactions_input
+    scope.map do |transaction|
+      {
+        id: transaction.id,
+        amount: transaction.entry.amount.abs,
+        classification: transaction.entry.classification,
+        description: transaction.entry.name,
+        merchant: transaction.merchant&.name
+      }
     end
+  end
 
-    def scope
-      family.transactions.where(id: transaction_ids, category_id: nil)
-                         .enrichable(:category_id)
-                         .includes(:category, :merchant, :entry)
-    end
+  def scope
+    family.transactions.where(id: transaction_ids, category_id: nil)
+                       .enrichable(:category_id)
+                       .includes(:category, :merchant, :entry)
+  end
 end

--- a/app/models/family/auto_merchant_detector.rb
+++ b/app/models/family/auto_merchant_detector.rb
@@ -58,41 +58,41 @@ class Family::AutoMerchantDetector
   end
 
   private
-    attr_reader :family, :transaction_ids
+  attr_reader :family, :transaction_ids
 
-    # For now, OpenAI only, but this should work with any LLM concept provider
-    def llm_provider
-      Provider::Registry.get_provider(:openai)
-    end
+  # For now, OpenAI only, but this should work with any LLM concept provider
+  def llm_provider
+    Provider::Registry.get_provider(:openai)
+  end
 
-    def default_logo_provider_url
-      "https://logo.synthfinance.com"
-    end
+  def default_logo_provider_url
+    "https://logo.synthfinance.com"
+  end
 
-    def user_merchants_input
-      family.merchants.map do |merchant|
-        {
-          id: merchant.id,
-          name: merchant.name
-        }
-      end
+  def user_merchants_input
+    family.merchants.map do |merchant|
+      {
+        id: merchant.id,
+        name: merchant.name
+      }
     end
+  end
 
-    def transactions_input
-      scope.map do |transaction|
-        {
-          id: transaction.id,
-          amount: transaction.entry.amount.abs,
-          classification: transaction.entry.classification,
-          description: transaction.entry.name,
-          merchant: transaction.merchant&.name
-        }
-      end
+  def transactions_input
+    scope.map do |transaction|
+      {
+        id: transaction.id,
+        amount: transaction.entry.amount.abs,
+        classification: transaction.entry.classification,
+        description: transaction.entry.name,
+        merchant: transaction.merchant&.name
+      }
     end
+  end
 
-    def scope
-      family.transactions.where(id: transaction_ids, merchant_id: nil)
-                         .enrichable(:merchant_id)
-                         .includes(:merchant, :entry)
-    end
+  def scope
+    family.transactions.where(id: transaction_ids, merchant_id: nil)
+                       .enrichable(:merchant_id)
+                       .includes(:merchant, :entry)
+  end
 end

--- a/app/models/family/data_exporter.rb
+++ b/app/models/family/data_exporter.rb
@@ -37,202 +37,202 @@ class Family::DataExporter
 
   private
 
-    def generate_accounts_csv
-      CSV.generate do |csv|
-        csv << ["id", "name", "type", "subtype", "balance", "currency", "created_at"]
+  def generate_accounts_csv
+    CSV.generate do |csv|
+      csv << ["id", "name", "type", "subtype", "balance", "currency", "created_at"]
 
-        # Only export accounts belonging to this family
-        @family.accounts.includes(:accountable).find_each do |account|
-          csv << [
-            account.id,
-            account.name,
-            account.accountable_type,
-            account.subtype,
-            account.balance.to_s,
-            account.currency,
-            account.created_at.iso8601
-          ]
-        end
-      end
-    end
-
-    def generate_transactions_csv
-      CSV.generate do |csv|
-        csv << ["date", "account_name", "amount", "name", "category", "tags", "notes", "currency"]
-
-        # Only export transactions from accounts belonging to this family
-        @family.transactions
-          .includes(:category, :tags, entry: :account)
-          .find_each do |transaction|
-            csv << [
-              transaction.entry.date.iso8601,
-              transaction.entry.account.name,
-              transaction.entry.amount.to_s,
-              transaction.entry.name,
-              transaction.category&.name,
-              transaction.tags.pluck(:name).join(","),
-              transaction.entry.notes,
-              transaction.entry.currency
-            ]
-          end
-      end
-    end
-
-    def generate_trades_csv
-      CSV.generate do |csv|
-        csv << ["date", "account_name", "ticker", "quantity", "price", "amount", "currency"]
-
-        # Only export trades from accounts belonging to this family
-        @family.trades
-          .includes(:security, entry: :account)
-          .find_each do |trade|
-            csv << [
-              trade.entry.date.iso8601,
-              trade.entry.account.name,
-              trade.security.ticker,
-              trade.qty.to_s,
-              trade.price.to_s,
-              trade.entry.amount.to_s,
-              trade.currency
-            ]
-          end
-      end
-    end
-
-    def generate_categories_csv
-      CSV.generate do |csv|
-        csv << ["name", "color", "parent_category", "classification"]
-
-        # Only export categories belonging to this family
-        @family.categories.includes(:parent).find_each do |category|
-          csv << [
-            category.name,
-            category.color,
-            category.parent&.name,
-            category.classification
-          ]
-        end
-      end
-    end
-
-    def generate_ndjson
-      lines = []
-
-      # Export accounts with full accountable data
+      # Only export accounts belonging to this family
       @family.accounts.includes(:accountable).find_each do |account|
-        lines << {
-          type: "Account",
-          data: account.as_json(
-            include: {
-              accountable: {}
-            }
-          )
-        }.to_json
+        csv << [
+          account.id,
+          account.name,
+          account.accountable_type,
+          account.subtype,
+          account.balance.to_s,
+          account.currency,
+          account.created_at.iso8601
+        ]
       end
-
-      # Export categories
-      @family.categories.find_each do |category|
-        lines << {
-          type: "Category",
-          data: category.as_json
-        }.to_json
-      end
-
-      # Export tags
-      @family.tags.find_each do |tag|
-        lines << {
-          type: "Tag",
-          data: tag.as_json
-        }.to_json
-      end
-
-      # Export merchants (only family merchants)
-      @family.merchants.find_each do |merchant|
-        lines << {
-          type: "Merchant",
-          data: merchant.as_json
-        }.to_json
-      end
-
-      # Export transactions with full data
-      @family.transactions.includes(:category, :merchant, :tags, entry: :account).find_each do |transaction|
-        lines << {
-          type: "Transaction",
-          data: {
-            id: transaction.id,
-            entry_id: transaction.entry.id,
-            account_id: transaction.entry.account_id,
-            date: transaction.entry.date,
-            amount: transaction.entry.amount,
-            currency: transaction.entry.currency,
-            name: transaction.entry.name,
-            notes: transaction.entry.notes,
-            excluded: transaction.entry.excluded,
-            category_id: transaction.category_id,
-            merchant_id: transaction.merchant_id,
-            tag_ids: transaction.tag_ids,
-            kind: transaction.kind,
-            created_at: transaction.created_at,
-            updated_at: transaction.updated_at
-          }
-        }.to_json
-      end
-
-      # Export trades with full data
-      @family.trades.includes(:security, entry: :account).find_each do |trade|
-        lines << {
-          type: "Trade",
-          data: {
-            id: trade.id,
-            entry_id: trade.entry.id,
-            account_id: trade.entry.account_id,
-            security_id: trade.security_id,
-            ticker: trade.security.ticker,
-            date: trade.entry.date,
-            qty: trade.qty,
-            price: trade.price,
-            amount: trade.entry.amount,
-            currency: trade.currency,
-            created_at: trade.created_at,
-            updated_at: trade.updated_at
-          }
-        }.to_json
-      end
-
-      # Export valuations
-      @family.entries.valuations.includes(:account, :entryable).find_each do |entry|
-        lines << {
-          type: "Valuation",
-          data: {
-            id: entry.entryable.id,
-            entry_id: entry.id,
-            account_id: entry.account_id,
-            date: entry.date,
-            amount: entry.amount,
-            currency: entry.currency,
-            name: entry.name,
-            created_at: entry.created_at,
-            updated_at: entry.updated_at
-          }
-        }.to_json
-      end
-
-      # Export budgets
-      @family.budgets.find_each do |budget|
-        lines << {
-          type: "Budget",
-          data: budget.as_json
-        }.to_json
-      end
-
-      # Export budget categories
-      @family.budget_categories.includes(:budget, :category).find_each do |budget_category|
-        lines << {
-          type: "BudgetCategory",
-          data: budget_category.as_json
-        }.to_json
-      end
-
-      lines.join("\n")
     end
+  end
+
+  def generate_transactions_csv
+    CSV.generate do |csv|
+      csv << ["date", "account_name", "amount", "name", "category", "tags", "notes", "currency"]
+
+      # Only export transactions from accounts belonging to this family
+      @family.transactions
+        .includes(:category, :tags, entry: :account)
+        .find_each do |transaction|
+          csv << [
+            transaction.entry.date.iso8601,
+            transaction.entry.account.name,
+            transaction.entry.amount.to_s,
+            transaction.entry.name,
+            transaction.category&.name,
+            transaction.tags.pluck(:name).join(","),
+            transaction.entry.notes,
+            transaction.entry.currency
+          ]
+        end
+    end
+  end
+
+  def generate_trades_csv
+    CSV.generate do |csv|
+      csv << ["date", "account_name", "ticker", "quantity", "price", "amount", "currency"]
+
+      # Only export trades from accounts belonging to this family
+      @family.trades
+        .includes(:security, entry: :account)
+        .find_each do |trade|
+          csv << [
+            trade.entry.date.iso8601,
+            trade.entry.account.name,
+            trade.security.ticker,
+            trade.qty.to_s,
+            trade.price.to_s,
+            trade.entry.amount.to_s,
+            trade.currency
+          ]
+        end
+    end
+  end
+
+  def generate_categories_csv
+    CSV.generate do |csv|
+      csv << ["name", "color", "parent_category", "classification"]
+
+      # Only export categories belonging to this family
+      @family.categories.includes(:parent).find_each do |category|
+        csv << [
+          category.name,
+          category.color,
+          category.parent&.name,
+          category.classification
+        ]
+      end
+    end
+  end
+
+  def generate_ndjson
+    lines = []
+
+    # Export accounts with full accountable data
+    @family.accounts.includes(:accountable).find_each do |account|
+      lines << {
+        type: "Account",
+        data: account.as_json(
+          include: {
+            accountable: {}
+          }
+        )
+      }.to_json
+    end
+
+    # Export categories
+    @family.categories.find_each do |category|
+      lines << {
+        type: "Category",
+        data: category.as_json
+      }.to_json
+    end
+
+    # Export tags
+    @family.tags.find_each do |tag|
+      lines << {
+        type: "Tag",
+        data: tag.as_json
+      }.to_json
+    end
+
+    # Export merchants (only family merchants)
+    @family.merchants.find_each do |merchant|
+      lines << {
+        type: "Merchant",
+        data: merchant.as_json
+      }.to_json
+    end
+
+    # Export transactions with full data
+    @family.transactions.includes(:category, :merchant, :tags, entry: :account).find_each do |transaction|
+      lines << {
+        type: "Transaction",
+        data: {
+          id: transaction.id,
+          entry_id: transaction.entry.id,
+          account_id: transaction.entry.account_id,
+          date: transaction.entry.date,
+          amount: transaction.entry.amount,
+          currency: transaction.entry.currency,
+          name: transaction.entry.name,
+          notes: transaction.entry.notes,
+          excluded: transaction.entry.excluded,
+          category_id: transaction.category_id,
+          merchant_id: transaction.merchant_id,
+          tag_ids: transaction.tag_ids,
+          kind: transaction.kind,
+          created_at: transaction.created_at,
+          updated_at: transaction.updated_at
+        }
+      }.to_json
+    end
+
+    # Export trades with full data
+    @family.trades.includes(:security, entry: :account).find_each do |trade|
+      lines << {
+        type: "Trade",
+        data: {
+          id: trade.id,
+          entry_id: trade.entry.id,
+          account_id: trade.entry.account_id,
+          security_id: trade.security_id,
+          ticker: trade.security.ticker,
+          date: trade.entry.date,
+          qty: trade.qty,
+          price: trade.price,
+          amount: trade.entry.amount,
+          currency: trade.currency,
+          created_at: trade.created_at,
+          updated_at: trade.updated_at
+        }
+      }.to_json
+    end
+
+    # Export valuations
+    @family.entries.valuations.includes(:account, :entryable).find_each do |entry|
+      lines << {
+        type: "Valuation",
+        data: {
+          id: entry.entryable.id,
+          entry_id: entry.id,
+          account_id: entry.account_id,
+          date: entry.date,
+          amount: entry.amount,
+          currency: entry.currency,
+          name: entry.name,
+          created_at: entry.created_at,
+          updated_at: entry.updated_at
+        }
+      }.to_json
+    end
+
+    # Export budgets
+    @family.budgets.find_each do |budget|
+      lines << {
+        type: "Budget",
+        data: budget.as_json
+      }.to_json
+    end
+
+    # Export budget categories
+    @family.budget_categories.includes(:budget, :category).find_each do |budget_category|
+      lines << {
+        type: "BudgetCategory",
+        data: budget_category.as_json
+      }.to_json
+    end
+
+    lines.join("\n")
+  end
 end

--- a/app/models/family/plaid_connectable.rb
+++ b/app/models/family/plaid_connectable.rb
@@ -42,7 +42,7 @@ module Family::PlaidConnectable
   end
 
   private
-    def plaid(region)
-      Provider::Registry.plaid_provider_for_region(region)
-    end
+  def plaid(region)
+    Provider::Registry.plaid_provider_for_region(region)
+  end
 end

--- a/app/models/family/syncer.rb
+++ b/app/models/family/syncer.rb
@@ -25,7 +25,7 @@ class Family::Syncer
   end
 
   private
-    def child_syncables
-      family.plaid_items + family.accounts.manual
-    end
+  def child_syncables
+    family.plaid_items + family.accounts.manual
+  end
 end

--- a/app/models/family_merchant.rb
+++ b/app/models/family_merchant.rb
@@ -9,7 +9,7 @@ class FamilyMerchant < Merchant
   validates :name, uniqueness: { scope: :family }
 
   private
-    def set_default_color
-      self.color = COLORS.sample
-    end
+  def set_default_color
+    self.color = COLORS.sample
+  end
 end

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -61,13 +61,13 @@ class Holding < ApplicationRecord
   end
 
   private
-    def calculate_trend
-      return nil unless amount_money
+  def calculate_trend
+    return nil unless amount_money
 
-      start_amount = qty * avg_cost
+    start_amount = qty * avg_cost
 
-      Trend.new \
-        current: amount_money,
-        previous: start_amount
-    end
+    Trend.new \
+      current: amount_money,
+      previous: start_amount
+  end
 end

--- a/app/models/holding/forward_calculator.rb
+++ b/app/models/holding/forward_calculator.rb
@@ -23,50 +23,50 @@ class Holding::ForwardCalculator
   end
 
   private
-    def portfolio_cache
-      @portfolio_cache ||= Holding::PortfolioCache.new(account)
+  def portfolio_cache
+    @portfolio_cache ||= Holding::PortfolioCache.new(account)
+  end
+
+  def empty_portfolio
+    securities = portfolio_cache.get_securities
+    securities.each_with_object({}) { |security, hash| hash[security.id] = 0 }
+  end
+
+  def generate_starting_portfolio
+    empty_portfolio
+  end
+
+  def transform_portfolio(previous_portfolio, trade_entries, direction: :forward)
+    new_quantities = previous_portfolio.dup
+
+    trade_entries.each do |trade_entry|
+      trade = trade_entry.entryable
+      security_id = trade.security_id
+      qty_change = trade.qty
+      qty_change = qty_change * -1 if direction == :reverse
+      new_quantities[security_id] = (new_quantities[security_id] || 0) + qty_change
     end
 
-    def empty_portfolio
-      securities = portfolio_cache.get_securities
-      securities.each_with_object({}) { |security, hash| hash[security.id] = 0 }
-    end
+    new_quantities
+  end
 
-    def generate_starting_portfolio
-      empty_portfolio
-    end
+  def build_holdings(portfolio, date, price_source: nil)
+    portfolio.map do |security_id, qty|
+      price = portfolio_cache.get_price(security_id, date, source: price_source)
 
-    def transform_portfolio(previous_portfolio, trade_entries, direction: :forward)
-      new_quantities = previous_portfolio.dup
-
-      trade_entries.each do |trade_entry|
-        trade = trade_entry.entryable
-        security_id = trade.security_id
-        qty_change = trade.qty
-        qty_change = qty_change * -1 if direction == :reverse
-        new_quantities[security_id] = (new_quantities[security_id] || 0) + qty_change
+      if price.nil?
+        next
       end
 
-      new_quantities
-    end
-
-    def build_holdings(portfolio, date, price_source: nil)
-      portfolio.map do |security_id, qty|
-        price = portfolio_cache.get_price(security_id, date, source: price_source)
-
-        if price.nil?
-          next
-        end
-
-        Holding.new(
-          account_id: account.id,
-          security_id: security_id,
-          date: date,
-          qty: qty,
-          price: price.price,
-          currency: price.currency,
-          amount: qty * price.price
-        )
-      end.compact
-    end
+      Holding.new(
+        account_id: account.id,
+        security_id: security_id,
+        date: date,
+        qty: qty,
+        price: price.price,
+        currency: price.currency,
+        amount: qty * price.price
+      )
+    end.compact
+  end
 end

--- a/app/models/holding/materializer.rb
+++ b/app/models/holding/materializer.rb
@@ -20,42 +20,42 @@ class Holding::Materializer
   end
 
   private
-    attr_reader :account, :strategy
+  attr_reader :account, :strategy
 
-    def calculate_holdings
-      @holdings = calculator.calculate
+  def calculate_holdings
+    @holdings = calculator.calculate
+  end
+
+  def persist_holdings
+    current_time = Time.now
+
+    account.holdings.upsert_all(
+      @holdings.map { |h| h.attributes
+             .slice("date", "currency", "qty", "price", "amount", "security_id")
+             .merge("account_id" => account.id, "updated_at" => current_time) },
+      unique_by: %i[account_id security_id date currency]
+    )
+  end
+
+  def purge_stale_holdings
+    portfolio_security_ids = account.entries.trades.map { |entry| entry.entryable.security_id }.uniq
+
+    # If there are no securities in the portfolio, delete all holdings
+    if portfolio_security_ids.empty?
+      Rails.logger.info("Clearing all holdings (no securities)")
+      account.holdings.delete_all
+    else
+      deleted_count = account.holdings.delete_by("date < ? OR security_id NOT IN (?)", account.start_date, portfolio_security_ids)
+      Rails.logger.info("Purged #{deleted_count} stale holdings") if deleted_count > 0
     end
+  end
 
-    def persist_holdings
-      current_time = Time.now
-
-      account.holdings.upsert_all(
-        @holdings.map { |h| h.attributes
-               .slice("date", "currency", "qty", "price", "amount", "security_id")
-               .merge("account_id" => account.id, "updated_at" => current_time) },
-        unique_by: %i[account_id security_id date currency]
-      )
+  def calculator
+    if strategy == :reverse
+      portfolio_snapshot = Holding::PortfolioSnapshot.new(account)
+      Holding::ReverseCalculator.new(account, portfolio_snapshot: portfolio_snapshot)
+    else
+      Holding::ForwardCalculator.new(account)
     end
-
-    def purge_stale_holdings
-      portfolio_security_ids = account.entries.trades.map { |entry| entry.entryable.security_id }.uniq
-
-      # If there are no securities in the portfolio, delete all holdings
-      if portfolio_security_ids.empty?
-        Rails.logger.info("Clearing all holdings (no securities)")
-        account.holdings.delete_all
-      else
-        deleted_count = account.holdings.delete_by("date < ? OR security_id NOT IN (?)", account.start_date, portfolio_security_ids)
-        Rails.logger.info("Purged #{deleted_count} stale holdings") if deleted_count > 0
-      end
-    end
-
-    def calculator
-      if strategy == :reverse
-        portfolio_snapshot = Holding::PortfolioSnapshot.new(account)
-        Holding::ReverseCalculator.new(account, portfolio_snapshot: portfolio_snapshot)
-      else
-        Holding::ForwardCalculator.new(account)
-      end
-    end
+  end
 end

--- a/app/models/holding/portfolio_snapshot.rb
+++ b/app/models/holding/portfolio_snapshot.rb
@@ -14,19 +14,19 @@ class Holding::PortfolioSnapshot
   end
 
   private
-    def build_portfolio
-      # Start with all securities from trades initialized to 0
-      portfolio = account.trades
-        .pluck(:security_id)
-        .uniq
-        .each_with_object({}) { |security_id, hash| hash[security_id] = 0 }
+  def build_portfolio
+    # Start with all securities from trades initialized to 0
+    portfolio = account.trades
+      .pluck(:security_id)
+      .uniq
+      .each_with_object({}) { |security_id, hash| hash[security_id] = 0 }
 
-      # Get the most recent holding for each security and update quantities
-      account.holdings
-        .select("DISTINCT ON (security_id) security_id, qty")
-        .order(:security_id, date: :desc)
-        .each { |holding| portfolio[holding.security_id] = holding.qty }
+    # Get the most recent holding for each security and update quantities
+    account.holdings
+      .select("DISTINCT ON (security_id) security_id, qty")
+      .order(:security_id, date: :desc)
+      .each { |holding| portfolio[holding.security_id] = holding.qty }
 
-      portfolio
-    end
+    portfolio
+  end
 end

--- a/app/models/holding/reverse_calculator.rb
+++ b/app/models/holding/reverse_calculator.rb
@@ -14,63 +14,63 @@ class Holding::ReverseCalculator
   end
 
   private
-    # Reverse calculators will use the existing holdings as a source of security ids and prices
-    # since it is common for a provider to supply "current day" holdings but not all the historical
-    # trades that make up those holdings.
-    def portfolio_cache
-      @portfolio_cache ||= Holding::PortfolioCache.new(account, use_holdings: true)
+  # Reverse calculators will use the existing holdings as a source of security ids and prices
+  # since it is common for a provider to supply "current day" holdings but not all the historical
+  # trades that make up those holdings.
+  def portfolio_cache
+    @portfolio_cache ||= Holding::PortfolioCache.new(account, use_holdings: true)
+  end
+
+  def calculate_holdings
+    # Start with the portfolio snapshot passed in from the materializer
+    current_portfolio = portfolio_snapshot.to_h
+    previous_portfolio = {}
+
+    holdings = []
+
+    Date.current.downto(account.start_date).each do |date|
+      today_trades = portfolio_cache.get_trades(date: date)
+      previous_portfolio = transform_portfolio(current_portfolio, today_trades, direction: :reverse)
+
+      # If current day, always use holding prices (since that's what Plaid gives us).  For historical values, use market data (since Plaid doesn't supply historical prices)
+      holdings += build_holdings(current_portfolio, date, price_source: date == Date.current ? "holding" : nil)
+      current_portfolio = previous_portfolio
     end
 
-    def calculate_holdings
-      # Start with the portfolio snapshot passed in from the materializer
-      current_portfolio = portfolio_snapshot.to_h
-      previous_portfolio = {}
+    holdings
+  end
 
-      holdings = []
+  def transform_portfolio(previous_portfolio, trade_entries, direction: :forward)
+    new_quantities = previous_portfolio.dup
 
-      Date.current.downto(account.start_date).each do |date|
-        today_trades = portfolio_cache.get_trades(date: date)
-        previous_portfolio = transform_portfolio(current_portfolio, today_trades, direction: :reverse)
+    trade_entries.each do |trade_entry|
+      trade = trade_entry.entryable
+      security_id = trade.security_id
+      qty_change = trade.qty
+      qty_change = qty_change * -1 if direction == :reverse
+      new_quantities[security_id] = (new_quantities[security_id] || 0) + qty_change
+    end
 
-        # If current day, always use holding prices (since that's what Plaid gives us).  For historical values, use market data (since Plaid doesn't supply historical prices)
-        holdings += build_holdings(current_portfolio, date, price_source: date == Date.current ? "holding" : nil)
-        current_portfolio = previous_portfolio
+    new_quantities
+  end
+
+  def build_holdings(portfolio, date, price_source: nil)
+    portfolio.map do |security_id, qty|
+      price = portfolio_cache.get_price(security_id, date, source: price_source)
+
+      if price.nil?
+        next
       end
 
-      holdings
-    end
-
-    def transform_portfolio(previous_portfolio, trade_entries, direction: :forward)
-      new_quantities = previous_portfolio.dup
-
-      trade_entries.each do |trade_entry|
-        trade = trade_entry.entryable
-        security_id = trade.security_id
-        qty_change = trade.qty
-        qty_change = qty_change * -1 if direction == :reverse
-        new_quantities[security_id] = (new_quantities[security_id] || 0) + qty_change
-      end
-
-      new_quantities
-    end
-
-    def build_holdings(portfolio, date, price_source: nil)
-      portfolio.map do |security_id, qty|
-        price = portfolio_cache.get_price(security_id, date, source: price_source)
-
-        if price.nil?
-          next
-        end
-
-        Holding.new(
-          account_id: account.id,
-          security_id: security_id,
-          date: date,
-          qty: qty,
-          price: price.price,
-          currency: price.currency,
-          amount: qty * price.price
-        )
-      end.compact
-    end
+      Holding.new(
+        account_id: account.id,
+        security_id: security_id,
+        date: date,
+        qty: qty,
+        price: price.price,
+        currency: price.currency,
+        amount: qty * price.price
+      )
+    end.compact
+  end
 end

--- a/app/models/impersonation_session.rb
+++ b/app/models/impersonation_session.rb
@@ -25,15 +25,15 @@ class ImpersonationSession < ApplicationRecord
   end
 
   private
-    def impersonator_is_super_admin
-      errors.add(:impersonator, "must be a super admin to impersonate") unless impersonator.super_admin?
-    end
+  def impersonator_is_super_admin
+    errors.add(:impersonator, "must be a super admin to impersonate") unless impersonator.super_admin?
+  end
 
-    def impersonated_is_not_super_admin
-      errors.add(:impersonated, "cannot be a super admin") if impersonated.super_admin?
-    end
+  def impersonated_is_not_super_admin
+    errors.add(:impersonated, "cannot be a super admin") if impersonated.super_admin?
+  end
 
-    def impersonator_different_from_impersonated
-      errors.add(:impersonator, "cannot be the same as the impersonated user") if impersonator == impersonated
-    end
+  def impersonator_different_from_impersonated
+    errors.add(:impersonator, "cannot be the same as the impersonated user") if impersonator == impersonated
+  end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -220,61 +220,61 @@ class Import < ApplicationRecord
   end
 
   private
-    def row_count_exceeded?
-      rows.count > max_row_count
-    end
+  def row_count_exceeded?
+    rows.count > max_row_count
+  end
 
-    def import!
-      # no-op, subclasses can implement for customization of algorithm
-    end
+  def import!
+    # no-op, subclasses can implement for customization of algorithm
+  end
 
-    def default_row_name
-      "Imported item"
-    end
+  def default_row_name
+    "Imported item"
+  end
 
-    def default_currency
-      family.currency
-    end
+  def default_currency
+    family.currency
+  end
 
-    def parsed_csv
-      @parsed_csv ||= self.class.parse_csv_str(raw_file_str, col_sep: col_sep)
-    end
+  def parsed_csv
+    @parsed_csv ||= self.class.parse_csv_str(raw_file_str, col_sep: col_sep)
+  end
 
-    def sanitize_number(value)
-      return "" if value.nil?
+  def sanitize_number(value)
+    return "" if value.nil?
 
-      format = NUMBER_FORMATS[number_format]
-      return "" unless format
+    format = NUMBER_FORMATS[number_format]
+    return "" unless format
 
-      # First, normalize spaces and remove any characters that aren't numbers, delimiters, separators, or minus signs
-      sanitized = value.to_s.strip
+    # First, normalize spaces and remove any characters that aren't numbers, delimiters, separators, or minus signs
+    sanitized = value.to_s.strip
 
-      # Handle French/Scandinavian format specially
-      if format[:delimiter] == " "
-        sanitized = sanitized.gsub(/\s+/, "") # Remove all spaces first
-      else
-        sanitized = sanitized.gsub(/[^\d#{Regexp.escape(format[:delimiter])}#{Regexp.escape(format[:separator])}\-]/, "")
+    # Handle French/Scandinavian format specially
+    if format[:delimiter] == " "
+      sanitized = sanitized.gsub(/\s+/, "") # Remove all spaces first
+    else
+      sanitized = sanitized.gsub(/[^\d#{Regexp.escape(format[:delimiter])}#{Regexp.escape(format[:separator])}\-]/, "")
 
-        # Replace delimiter with empty string
-        if format[:delimiter].present?
-          sanitized = sanitized.gsub(format[:delimiter], "")
-        end
+      # Replace delimiter with empty string
+      if format[:delimiter].present?
+        sanitized = sanitized.gsub(format[:delimiter], "")
       end
-
-      # Replace separator with period for proper float parsing
-      if format[:separator].present?
-        sanitized = sanitized.gsub(format[:separator], ".")
-      end
-
-      # Return empty string if not a valid number
-      unless sanitized =~ /\A-?\d+\.?\d*\z/
-        return ""
-      end
-
-      sanitized
     end
 
-    def set_default_number_format
-      self.number_format ||= "1,234.56" # Default to US/UK format
+    # Replace separator with period for proper float parsing
+    if format[:separator].present?
+      sanitized = sanitized.gsub(format[:separator], ".")
     end
+
+    # Return empty string if not a valid number
+    unless sanitized =~ /\A-?\d+\.?\d*\z/
+      return ""
+    end
+
+    sanitized
+  end
+
+  def set_default_number_format
+    self.number_format ||= "1,234.56" # Default to US/UK format
+  end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -46,29 +46,6 @@ class Import < ApplicationRecord
   has_many :entries, dependent: :destroy
 
   class << self
-    def find_header_index(csv_str, col_sep: ",")
-      lines = csv_str.split("\n")
-
-      lines.each_with_index do |line, index|
-        CSV_HEADER_PATTERNS.each do |_, patterns|
-          begin
-            cells = CSV.parse_line(line, col_sep: col_sep)
-            next if cells.nil? || cells.empty?
-
-            matches = cells.count do |cell|
-              next false if cell.nil?
-              patterns.any? { |pattern| cell.match?(pattern) }
-            end
-
-            return index if matches >= 2
-          rescue CSV::MalformedCSVError
-            next
-          end
-        end
-      end
-      0
-    end
-
     def parse_csv_str(csv_str, col_sep: ",")
       csv_str = (csv_str || "").strip
 
@@ -85,10 +62,45 @@ class Import < ApplicationRecord
         normalized_csv_str,
         headers: true,
         col_sep: col_sep,
-        converters: [->(str) { str&.strip }],
+        converters: [->(str) { str&.strip }, amount_converter],
         liberal_parsing: true
       )
     end
+
+    private
+
+      def find_header_index(csv_str, col_sep: ",")
+        lines = csv_str.split("\n")
+
+        lines.each_with_index do |line, index|
+          CSV_HEADER_PATTERNS.each do |_, patterns|
+            begin
+              cells = CSV.parse_line(line, col_sep: col_sep)
+              next if cells.nil? || cells.empty?
+
+              matches = cells.count do |cell|
+                next false if cell.nil?
+                patterns.any? { |pattern| cell.match?(pattern) }
+              end
+
+              return index if matches >= 2
+            rescue CSV::MalformedCSVError
+              next
+            end
+          end
+        end
+        0
+      end
+
+      def amount_converter
+        lambda do |str, field_metadata|
+          if field_metadata.header&.match?(/#Kwota/)
+            str&.gsub(/\s*[A-Z]{3}\s*$/, "")&.gsub(",", ".")
+          else
+            str
+          end
+        end
+      end
   end
 
   def publish_later

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,13 +1,11 @@
 class Import < ApplicationRecord
+  extend Import::CsvConverter
+
   MaxRowCountExceededError = Class.new(StandardError)
 
   TYPES = %w[TransactionImport TradeImport AccountImport MintImport].freeze
   SIGNAGE_CONVENTIONS = %w[inflows_positive inflows_negative]
   SEPARATORS = [["Comma (,)", ","], ["Semicolon (;)", ";"]].freeze
-  CSV_HEADER_PATTERNS = {
-    "mbank" => [/^#Data operacji/, /^#Opis operacji/, /^#Rachunek/, /^#Kategoria/, /^#Kwota/]
-  }
-
 
   NUMBER_FORMATS = {
     "1,234.56" => { separator: ".", delimiter: "," },  # US/UK/Asia
@@ -44,64 +42,6 @@ class Import < ApplicationRecord
   has_many :mappings, dependent: :destroy
   has_many :accounts, dependent: :destroy
   has_many :entries, dependent: :destroy
-
-  class << self
-    def parse_csv_str(csv_str, col_sep: ",")
-      csv_str = (csv_str || "").strip
-
-      header_index = find_header_index(csv_str, col_sep: col_sep)
-
-      normalized_csv_str = if header_index.zero?
-        csv_str
-      else
-        lines = csv_str.split("\n")
-        lines[header_index..].join("\n")
-      end
-
-      CSV.parse(
-        normalized_csv_str,
-        headers: true,
-        col_sep: col_sep,
-        converters: [->(str) { str&.strip }, amount_converter],
-        liberal_parsing: true
-      )
-    end
-
-    private
-
-      def find_header_index(csv_str, col_sep: ",")
-        lines = csv_str.split("\n")
-
-        lines.each_with_index do |line, index|
-          CSV_HEADER_PATTERNS.each do |_, patterns|
-            begin
-              cells = CSV.parse_line(line, col_sep: col_sep)
-              next if cells.nil? || cells.empty?
-
-              matches = cells.count do |cell|
-                next false if cell.nil?
-                patterns.any? { |pattern| cell.match?(pattern) }
-              end
-
-              return index if matches >= 2
-            rescue CSV::MalformedCSVError
-              next
-            end
-          end
-        end
-        0
-      end
-
-      def amount_converter
-        lambda do |str, field_metadata|
-          if field_metadata.header&.match?(/#Kwota/)
-            str&.gsub(/\s*[A-Z]{3}\s*$/, "")&.gsub(",", ".")
-          else
-            str
-          end
-        end
-      end
-  end
 
   def publish_later
     raise MaxRowCountExceededError if row_count_exceeded?

--- a/app/models/import/account_mapping.rb
+++ b/app/models/import/account_mapping.rb
@@ -47,7 +47,7 @@ class Import::AccountMapping < Import::Mapping
   end
 
   private
-    def requires_mapping?
-      (key.blank? || !create_when_empty) && import.account.nil?
-    end
+  def requires_mapping?
+    (key.blank? || !create_when_empty) && import.account.nil?
+  end
 end

--- a/app/models/import/csv_converter.rb
+++ b/app/models/import/csv_converter.rb
@@ -1,0 +1,61 @@
+module Import::CsvConverter
+  CSV_HEADER_PATTERNS = {
+    "mbank" => [/^#Data operacji/, /^#Opis operacji/, /^#Rachunek/, /^#Kategoria/, /^#Kwota/]
+  }
+
+  def parse_csv_str(csv_str, col_sep: ",")
+    csv_str = (csv_str || "").strip
+
+    header_index = find_header_index(csv_str, col_sep: col_sep)
+
+    normalized_csv_str = if header_index.zero?
+      csv_str
+    else
+      lines = csv_str.split("\n")
+      lines[header_index..].join("\n")
+    end
+
+    CSV.parse(
+      normalized_csv_str,
+      headers: true,
+      col_sep: col_sep,
+      converters: [->(str) { str&.strip }, amount_converter],
+      liberal_parsing: true
+    )
+  end
+
+    private
+
+      def find_header_index(csv_str, col_sep: ",")
+        lines = csv_str.split("\n")
+
+        lines.each_with_index do |line, index|
+          CSV_HEADER_PATTERNS.each do |_, patterns|
+            begin
+              cells = CSV.parse_line(line, col_sep: col_sep)
+              next if cells.nil? || cells.empty?
+
+              matches = cells.count do |cell|
+                next false if cell.nil?
+                patterns.any? { |pattern| cell.match?(pattern) }
+              end
+
+              return index if matches >= 2
+            rescue CSV::MalformedCSVError
+              next
+            end
+          end
+        end
+        0
+      end
+
+      def amount_converter
+        lambda do |str, field_metadata|
+          if field_metadata.header&.match?(/#Kwota/)
+            str&.gsub(/\s*[A-Z]{3}\s*$/, "")&.gsub(",", ".")
+          else
+            str
+          end
+        end
+      end
+end

--- a/app/models/import/csv_converter.rb
+++ b/app/models/import/csv_converter.rb
@@ -24,38 +24,38 @@ module Import::CsvConverter
     )
   end
 
-    private
+  private
 
-      def find_header_index(csv_str, col_sep: ",")
-        lines = csv_str.split("\n")
+  def find_header_index(csv_str, col_sep: ",")
+    lines = csv_str.split("\n")
 
-        lines.each_with_index do |line, index|
-          CSV_HEADER_PATTERNS.each do |_, patterns|
-            begin
-              cells = CSV.parse_line(line, col_sep: col_sep)
-              next if cells.nil? || cells.empty?
+    lines.each_with_index do |line, index|
+      CSV_HEADER_PATTERNS.each do |_, patterns|
+        begin
+          cells = CSV.parse_line(line, col_sep: col_sep)
+          next if cells.nil? || cells.empty?
 
-              matches = cells.count do |cell|
-                next false if cell.nil?
-                patterns.any? { |pattern| cell.match?(pattern) }
-              end
-
-              return index if matches >= 2
-            rescue CSV::MalformedCSVError
-              next
-            end
+          matches = cells.count do |cell|
+            next false if cell.nil?
+            patterns.any? { |pattern| cell.match?(pattern) }
           end
-        end
-        0
-      end
 
-      def amount_converter
-        lambda do |str, field_metadata|
-          if field_metadata.header&.match?(/#Kwota/)
-            str&.gsub(/\s*[A-Z]{3}\s*$/, "")&.gsub(",", ".")
-          else
-            str
-          end
+          return index if matches >= 2
+        rescue CSV::MalformedCSVError
+          next
         end
       end
+    end
+    0
+  end
+
+  def amount_converter
+    lambda do |str, field_metadata|
+      if field_metadata.header&.match?(/#Kwota/)
+        str&.gsub(/\s*[A-Z]{3}\s*$/, "")&.gsub(",", ".")
+      else
+        str
+      end
+    end
+  end
 end

--- a/app/models/import/row.rb
+++ b/app/models/import/row.rb
@@ -37,59 +37,59 @@ class Import::Row < ApplicationRecord
   end
 
   private
-    # In the Maybe system, positive quantities == "inflows"
-    def apply_trade_signage_convention(value)
-      value * (import.signage_convention == "inflows_positive" ? 1 : -1)
-    end
+  # In the Maybe system, positive quantities == "inflows"
+  def apply_trade_signage_convention(value)
+    value * (import.signage_convention == "inflows_positive" ? 1 : -1)
+  end
 
-    # In the Maybe system, positive amounts == "outflows", so we must reverse signage
-    def apply_transaction_signage_convention(value)
-      if import.amount_type_strategy == "signed_amount"
-        value * (import.signage_convention == "inflows_positive" ? -1 : 1)
-      elsif import.amount_type_strategy == "custom_column"
-        inflow_value = import.amount_type_inflow_value
+  # In the Maybe system, positive amounts == "outflows", so we must reverse signage
+  def apply_transaction_signage_convention(value)
+    if import.amount_type_strategy == "signed_amount"
+      value * (import.signage_convention == "inflows_positive" ? -1 : 1)
+    elsif import.amount_type_strategy == "custom_column"
+      inflow_value = import.amount_type_inflow_value
 
-        if entity_type == inflow_value
-          value * -1
-        else
-          value
-        end
+      if entity_type == inflow_value
+        value * -1
       else
-        raise "Unknown amount type strategy for import: #{import.amount_type_strategy}"
+        value
       end
+    else
+      raise "Unknown amount type strategy for import: #{import.amount_type_strategy}"
+    end
+  end
+
+  def required_columns
+    import.required_column_keys.each do |required_key|
+      errors.add(required_key, "is required") if self[required_key].blank?
+    end
+  end
+
+  def date_valid
+    return if date.blank?
+
+    parsed_date = Date.strptime(date, import.date_format) rescue nil
+
+    if parsed_date.nil?
+      errors.add(:date, "must exactly match the format: #{import.date_format}")
+      return
     end
 
-    def required_columns
-      import.required_column_keys.each do |required_key|
-        errors.add(required_key, "is required") if self[required_key].blank?
-      end
+    min_date = Entry.min_supported_date
+    max_date = Date.current
+
+    if parsed_date < min_date || parsed_date > max_date
+      errors.add(:date, "must be between #{min_date} and #{max_date}")
     end
+  end
 
-    def date_valid
-      return if date.blank?
+  def currency_is_valid
+    return true if currency.blank?
 
-      parsed_date = Date.strptime(date, import.date_format) rescue nil
-
-      if parsed_date.nil?
-        errors.add(:date, "must exactly match the format: #{import.date_format}")
-        return
-      end
-
-      min_date = Entry.min_supported_date
-      max_date = Date.current
-
-      if parsed_date < min_date || parsed_date > max_date
-        errors.add(:date, "must be between #{min_date} and #{max_date}")
-      end
+    begin
+      Money::Currency.new(currency)
+    rescue Money::Currency::UnknownCurrencyError
+      errors.add(:currency, "is not a valid currency code")
     end
-
-    def currency_is_valid
-      return true if currency.blank?
-
-      begin
-        Money::Currency.new(currency)
-      rescue Money::Currency::UnknownCurrencyError
-        errors.add(:currency, "is not a valid currency code")
-      end
-    end
+  end
 end

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -53,74 +53,74 @@ class IncomeStatement
   end
 
   private
-    ScopeTotals = Data.define(:transactions_count, :income_money, :expense_money)
-    PeriodTotal = Data.define(:classification, :total, :currency, :category_totals)
-    CategoryTotal = Data.define(:category, :total, :currency, :weight)
+  ScopeTotals = Data.define(:transactions_count, :income_money, :expense_money)
+  PeriodTotal = Data.define(:classification, :total, :currency, :category_totals)
+  CategoryTotal = Data.define(:category, :total, :currency, :weight)
 
-    def categories
-      @categories ||= family.categories.all.to_a
-    end
+  def categories
+    @categories ||= family.categories.all.to_a
+  end
 
-    def build_period_total(classification:, period:)
-      totals = totals_query(transactions_scope: family.transactions.visible.in_period(period)).select { |t| t.classification == classification }
-      classification_total = totals.sum(&:total)
+  def build_period_total(classification:, period:)
+    totals = totals_query(transactions_scope: family.transactions.visible.in_period(period)).select { |t| t.classification == classification }
+    classification_total = totals.sum(&:total)
 
-      uncategorized_category = family.categories.uncategorized
+    uncategorized_category = family.categories.uncategorized
 
-      category_totals = [*categories, uncategorized_category].map do |category|
-        subcategory = categories.find { |c| c.id == category.parent_id }
+    category_totals = [*categories, uncategorized_category].map do |category|
+      subcategory = categories.find { |c| c.id == category.parent_id }
 
-        parent_category_total = totals.select { |t| t.category_id == category.id }&.sum(&:total) || 0
+      parent_category_total = totals.select { |t| t.category_id == category.id }&.sum(&:total) || 0
 
-        children_totals = if category == uncategorized_category
-          0
-        else
-          totals.select { |t| t.parent_category_id == category.id }&.sum(&:total) || 0
-        end
-
-        category_total = parent_category_total + children_totals
-
-        weight = (category_total.zero? ? 0 : category_total.to_f / classification_total) * 100
-
-        CategoryTotal.new(
-          category: category,
-          total: category_total,
-          currency: family.currency,
-          weight: weight,
-        )
+      children_totals = if category == uncategorized_category
+        0
+      else
+        totals.select { |t| t.parent_category_id == category.id }&.sum(&:total) || 0
       end
 
-      PeriodTotal.new(
-        classification: classification,
-        total: category_totals.reject { |ct| ct.category.subcategory? }.sum(&:total),
+      category_total = parent_category_total + children_totals
+
+      weight = (category_total.zero? ? 0 : category_total.to_f / classification_total) * 100
+
+      CategoryTotal.new(
+        category: category,
+        total: category_total,
         currency: family.currency,
-        category_totals: category_totals
+        weight: weight,
       )
     end
 
-    def family_stats(interval: "month")
-      @family_stats ||= {}
-      @family_stats[interval] ||= Rails.cache.fetch([
-        "income_statement", "family_stats", family.id, interval, family.entries_cache_version
-      ]) { FamilyStats.new(family, interval:).call }
-    end
+    PeriodTotal.new(
+      classification: classification,
+      total: category_totals.reject { |ct| ct.category.subcategory? }.sum(&:total),
+      currency: family.currency,
+      category_totals: category_totals
+    )
+  end
 
-    def category_stats(interval: "month")
-      @category_stats ||= {}
-      @category_stats[interval] ||= Rails.cache.fetch([
-        "income_statement", "category_stats", family.id, interval, family.entries_cache_version
-      ]) { CategoryStats.new(family, interval:).call }
-    end
+  def family_stats(interval: "month")
+    @family_stats ||= {}
+    @family_stats[interval] ||= Rails.cache.fetch([
+      "income_statement", "family_stats", family.id, interval, family.entries_cache_version
+    ]) { FamilyStats.new(family, interval:).call }
+  end
 
-    def totals_query(transactions_scope:)
-      sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
+  def category_stats(interval: "month")
+    @category_stats ||= {}
+    @category_stats[interval] ||= Rails.cache.fetch([
+      "income_statement", "category_stats", family.id, interval, family.entries_cache_version
+    ]) { CategoryStats.new(family, interval:).call }
+  end
 
-      Rails.cache.fetch([
-        "income_statement", "totals_query", family.id, sql_hash, family.entries_cache_version
-      ]) { Totals.new(family, transactions_scope: transactions_scope).call }
-    end
+  def totals_query(transactions_scope:)
+    sql_hash = Digest::MD5.hexdigest(transactions_scope.to_sql)
 
-    def monetizable_currency
-      family.currency
-    end
+    Rails.cache.fetch([
+      "income_statement", "totals_query", family.id, sql_hash, family.entries_cache_version
+    ]) { Totals.new(family, transactions_scope: transactions_scope).call }
+  end
+
+  def monetizable_currency
+    family.currency
+  end
 end

--- a/app/models/income_statement/category_stats.rb
+++ b/app/models/income_statement/category_stats.rb
@@ -16,21 +16,21 @@ class IncomeStatement::CategoryStats
   end
 
   private
-    StatRow = Data.define(:category_id, :classification, :median, :avg)
+  StatRow = Data.define(:category_id, :classification, :median, :avg)
 
-    def sanitized_query_sql
-      ActiveRecord::Base.sanitize_sql_array([
-        query_sql,
-        {
-          target_currency: @family.currency,
-          interval: @interval,
-          family_id: @family.id
-        }
-      ])
-    end
+  def sanitized_query_sql
+    ActiveRecord::Base.sanitize_sql_array([
+      query_sql,
+      {
+        target_currency: @family.currency,
+        interval: @interval,
+        family_id: @family.id
+      }
+    ])
+  end
 
-    def query_sql
-      <<~SQL
+  def query_sql
+    <<~SQL
         WITH period_totals AS (
           SELECT
             c.id as category_id,
@@ -59,5 +59,5 @@ class IncomeStatement::CategoryStats
         FROM period_totals
         GROUP BY category_id, classification;
       SQL
-    end
+  end
 end

--- a/app/models/income_statement/family_stats.rb
+++ b/app/models/income_statement/family_stats.rb
@@ -15,21 +15,21 @@ class IncomeStatement::FamilyStats
   end
 
   private
-    StatRow = Data.define(:classification, :median, :avg)
+  StatRow = Data.define(:classification, :median, :avg)
 
-    def sanitized_query_sql
-      ActiveRecord::Base.sanitize_sql_array([
-        query_sql,
-        {
-          target_currency: @family.currency,
-          interval: @interval,
-          family_id: @family.id
-        }
-      ])
-    end
+  def sanitized_query_sql
+    ActiveRecord::Base.sanitize_sql_array([
+      query_sql,
+      {
+        target_currency: @family.currency,
+        interval: @interval,
+        family_id: @family.id
+      }
+    ])
+  end
 
-    def query_sql
-      <<~SQL
+  def query_sql
+    <<~SQL
         WITH period_totals AS (
           SELECT
             date_trunc(:interval, ae.date) as period,
@@ -55,5 +55,5 @@ class IncomeStatement::FamilyStats
         FROM period_totals
         GROUP BY classification;
       SQL
-    end
+  end
 end

--- a/app/models/income_statement/totals.rb
+++ b/app/models/income_statement/totals.rb
@@ -17,19 +17,19 @@ class IncomeStatement::Totals
   end
 
   private
-    TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :transactions_count)
+  TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :transactions_count)
 
-    def query_sql
-      ActiveRecord::Base.sanitize_sql_array([
-        optimized_query_sql,
-        sql_params
-      ])
-    end
+  def query_sql
+    ActiveRecord::Base.sanitize_sql_array([
+      optimized_query_sql,
+      sql_params
+    ])
+  end
 
-    # OPTIMIZED: Direct SUM aggregation without unnecessary time bucketing
-    # Eliminates CTE and intermediate date grouping for maximum performance
-    def optimized_query_sql
-      <<~SQL
+  # OPTIMIZED: Direct SUM aggregation without unnecessary time bucketing
+  # Eliminates CTE and intermediate date grouping for maximum performance
+  def optimized_query_sql
+    <<~SQL
         SELECT
           c.id as category_id,
           c.parent_id as parent_category_id,
@@ -48,11 +48,11 @@ class IncomeStatement::Totals
           AND ae.excluded = false
         GROUP BY c.id, c.parent_id, CASE WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END;
       SQL
-    end
+  end
 
-    def sql_params
-      {
-        target_currency: @family.currency
-      }
-    end
+  def sql_params
+    {
+      target_currency: @family.currency
+    }
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -20,18 +20,18 @@ class Invitation < ApplicationRecord
 
   private
 
-    def generate_token
-      loop do
-        self.token = SecureRandom.hex(32)
-        break unless self.class.exists?(token: token)
-      end
+  def generate_token
+    loop do
+      self.token = SecureRandom.hex(32)
+      break unless self.class.exists?(token: token)
     end
+  end
 
-    def set_expiration
-      self.expires_at = 3.days.from_now
-    end
+  def set_expiration
+    self.expires_at = 3.days.from_now
+  end
 
-    def inviter_is_admin
-      inviter.admin?
-    end
+  def inviter_is_admin
+    inviter.admin?
+  end
 end

--- a/app/models/invite_code.rb
+++ b/app/models/invite_code.rb
@@ -16,10 +16,10 @@ class InviteCode < ApplicationRecord
 
   private
 
-    def generate_token
-      loop do
-        self.token = SecureRandom.hex(4)
-        break token unless self.class.exists?(token: token)
-      end
+  def generate_token
+    loop do
+      self.token = SecureRandom.hex(4)
+      break token unless self.class.exists?(token: token)
     end
+  end
 end

--- a/app/models/market_data_importer.rb
+++ b/app/models/market_data_importer.rb
@@ -55,79 +55,79 @@ class MarketDataImporter
   end
 
   private
-    attr_reader :mode, :clear_cache
+  attr_reader :mode, :clear_cache
 
-    def snapshot?
-      mode.to_sym == :snapshot
+  def snapshot?
+    mode.to_sym == :snapshot
+  end
+
+  # Builds a unique list of currency pairs with the earliest date we need
+  # exchange rates for.
+  #
+  # Returns: Array of Hashes – [{ source:, target:, start_date: }, ...]
+  def required_exchange_rate_pairs
+    pair_dates = {} # { [source, target] => earliest_date }
+
+    # 1. ENTRY-BASED PAIRS – we need rates from the first entry date
+    Entry.joins(:account)
+         .where.not("entries.currency = accounts.currency")
+         .group("entries.currency", "accounts.currency")
+         .minimum("entries.date")
+         .each do |(source, target), date|
+      key = [source, target]
+      pair_dates[key] = [pair_dates[key], date].compact.min
     end
 
-    # Builds a unique list of currency pairs with the earliest date we need
-    # exchange rates for.
-    #
-    # Returns: Array of Hashes – [{ source:, target:, start_date: }, ...]
-    def required_exchange_rate_pairs
-      pair_dates = {} # { [source, target] => earliest_date }
+    # 2. ACCOUNT-BASED PAIRS – use the account's oldest entry date
+    account_first_entry_dates = Entry.group(:account_id).minimum(:date)
 
-      # 1. ENTRY-BASED PAIRS – we need rates from the first entry date
-      Entry.joins(:account)
-           .where.not("entries.currency = accounts.currency")
-           .group("entries.currency", "accounts.currency")
-           .minimum("entries.date")
-           .each do |(source, target), date|
-        key = [source, target]
-        pair_dates[key] = [pair_dates[key], date].compact.min
-      end
+    Account.joins(:family)
+           .where.not("families.currency = accounts.currency")
+           .select("accounts.id, accounts.currency AS source, families.currency AS target")
+           .find_each do |account|
+      earliest_entry_date = account_first_entry_dates[account.id]
 
-      # 2. ACCOUNT-BASED PAIRS – use the account's oldest entry date
-      account_first_entry_dates = Entry.group(:account_id).minimum(:date)
+      chosen_date = [earliest_entry_date, default_start_date].compact.min
 
-      Account.joins(:family)
-             .where.not("families.currency = accounts.currency")
-             .select("accounts.id, accounts.currency AS source, families.currency AS target")
-             .find_each do |account|
-        earliest_entry_date = account_first_entry_dates[account.id]
-
-        chosen_date = [earliest_entry_date, default_start_date].compact.min
-
-        key = [account.source, account.target]
-        pair_dates[key] = [pair_dates[key], chosen_date].compact.min
-      end
-
-      # Convert to array of hashes for ease of use
-      pair_dates.map do |(source, target), date|
-        { source: source, target: target, start_date: date }
-      end
+      key = [account.source, account.target]
+      pair_dates[key] = [pair_dates[key], chosen_date].compact.min
     end
 
-    def get_first_required_price_date(security)
-      return default_start_date if snapshot?
+    # Convert to array of hashes for ease of use
+    pair_dates.map do |(source, target), date|
+      { source: source, target: target, start_date: date }
+    end
+  end
 
-      Trade.with_entry.where(security: security).minimum(:date) || default_start_date
+  def get_first_required_price_date(security)
+    return default_start_date if snapshot?
+
+    Trade.with_entry.where(security: security).minimum(:date) || default_start_date
+  end
+
+  # An approximation that grabs more than we likely need, but simplifies the logic
+  def get_first_required_exchange_rate_date(from_currency:)
+    return default_start_date if snapshot?
+
+    Entry.where(currency: from_currency).minimum(:date) || default_start_date
+  end
+
+  def default_start_date
+    SNAPSHOT_DAYS.days.ago.to_date
+  end
+
+  # Since we're querying market data from a US-based API, end date should always be today (EST)
+  def end_date
+    Date.current.in_time_zone("America/New_York").to_date
+  end
+
+  def set_mode!(mode)
+    valid_modes = [:full, :snapshot]
+
+    unless valid_modes.include?(mode.to_sym)
+      raise InvalidModeError, "Invalid mode for MarketDataImporter, can only be :full or :snapshot, but was #{mode}"
     end
 
-    # An approximation that grabs more than we likely need, but simplifies the logic
-    def get_first_required_exchange_rate_date(from_currency:)
-      return default_start_date if snapshot?
-
-      Entry.where(currency: from_currency).minimum(:date) || default_start_date
-    end
-
-    def default_start_date
-      SNAPSHOT_DAYS.days.ago.to_date
-    end
-
-    # Since we're querying market data from a US-based API, end date should always be today (EST)
-    def end_date
-      Date.current.in_time_zone("America/New_York").to_date
-    end
-
-    def set_mode!(mode)
-      valid_modes = [:full, :snapshot]
-
-      unless valid_modes.include?(mode.to_sym)
-        raise InvalidModeError, "Invalid mode for MarketDataImporter, can only be :full or :snapshot, but was #{mode}"
-      end
-
-      mode.to_sym
-    end
+    mode.to_sym
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -16,7 +16,7 @@ class Message < ApplicationRecord
   scope :ordered, -> { order(created_at: :asc) }
 
   private
-    def broadcast?
-      true
-    end
+  def broadcast?
+    true
+  end
 end

--- a/app/models/mint_import.rb
+++ b/app/models/mint_import.rb
@@ -77,19 +77,19 @@ class MintImport < Import
   end
 
   private
-    def set_mappings
-      self.signage_convention = "inflows_positive"
-      self.date_col_label = "Date"
-      self.date_format = "%m/%d/%Y"
-      self.name_col_label = "Description"
-      self.amount_col_label = "Amount"
-      self.currency_col_label = "Currency"
-      self.account_col_label = "Account Name"
-      self.category_col_label = "Category"
-      self.tags_col_label = "Labels"
-      self.notes_col_label = "Notes"
-      self.entity_type_col_label = "Transaction Type"
+  def set_mappings
+    self.signage_convention = "inflows_positive"
+    self.date_col_label = "Date"
+    self.date_format = "%m/%d/%Y"
+    self.name_col_label = "Description"
+    self.amount_col_label = "Amount"
+    self.currency_col_label = "Currency"
+    self.account_col_label = "Account Name"
+    self.category_col_label = "Category"
+    self.tags_col_label = "Labels"
+    self.notes_col_label = "Notes"
+    self.entity_type_col_label = "Transaction Type"
 
-      save!
-    end
+    save!
+  end
 end

--- a/app/models/mobile_device.rb
+++ b/app/models/mobile_device.rb
@@ -49,7 +49,7 @@ class MobileDevice < ApplicationRecord
 
   private
 
-    def set_last_seen_at
-      self.last_seen_at ||= Time.current
-    end
+  def set_last_seen_at
+    self.last_seen_at ||= Time.current
+  end
 end

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -153,18 +153,18 @@ class Period
   end
 
   private
-    def key_metadata
-      @key_metadata ||= PERIODS[key]
+  def key_metadata
+    @key_metadata ||= PERIODS[key]
+  end
+
+  def must_be_valid_date_range
+    return if start_date.nil? || end_date.nil?
+    unless start_date.is_a?(Date) && end_date.is_a?(Date)
+      errors.add(:start_date, "must be a valid date, got #{start_date.inspect}")
+      errors.add(:end_date, "must be a valid date, got #{end_date.inspect}")
+      return
     end
 
-    def must_be_valid_date_range
-      return if start_date.nil? || end_date.nil?
-      unless start_date.is_a?(Date) && end_date.is_a?(Date)
-        errors.add(:start_date, "must be a valid date, got #{start_date.inspect}")
-        errors.add(:end_date, "must be a valid date, got #{end_date.inspect}")
-        return
-      end
-
-      errors.add(:start_date, "must be before end date") if start_date > end_date
-    end
+    errors.add(:start_date, "must be before end date") if start_date > end_date
+  end
 end

--- a/app/models/plaid_account.rb
+++ b/app/models/plaid_account.rb
@@ -46,9 +46,9 @@ class PlaidAccount < ApplicationRecord
   end
 
   private
-    # Plaid guarantees at least one of these.  This validation is a sanity check for that guarantee.
-    def has_balance
-      return if current_balance.present? || available_balance.present?
-      errors.add(:base, "Plaid account must have either current or available balance")
-    end
+  # Plaid guarantees at least one of these.  This validation is a sanity check for that guarantee.
+  def has_balance
+    return if current_balance.present? || available_balance.present?
+    errors.add(:base, "Plaid account must have either current or available balance")
+  end
 end

--- a/app/models/plaid_account/importer.rb
+++ b/app/models/plaid_account/importer.rb
@@ -12,21 +12,21 @@ class PlaidAccount::Importer
   end
 
   private
-    attr_reader :plaid_account, :account_snapshot
+  attr_reader :plaid_account, :account_snapshot
 
-    def import_account_info
-      plaid_account.upsert_plaid_snapshot!(account_snapshot.account_data)
-    end
+  def import_account_info
+    plaid_account.upsert_plaid_snapshot!(account_snapshot.account_data)
+  end
 
-    def import_transactions
-      plaid_account.upsert_plaid_transactions_snapshot!(account_snapshot.transactions_data)
-    end
+  def import_transactions
+    plaid_account.upsert_plaid_transactions_snapshot!(account_snapshot.transactions_data)
+  end
 
-    def import_investments
-      plaid_account.upsert_plaid_investments_snapshot!(account_snapshot.investments_data)
-    end
+  def import_investments
+    plaid_account.upsert_plaid_investments_snapshot!(account_snapshot.investments_data)
+  end
 
-    def import_liabilities
-      plaid_account.upsert_plaid_liabilities_snapshot!(account_snapshot.liabilities_data)
-    end
+  def import_liabilities
+    plaid_account.upsert_plaid_liabilities_snapshot!(account_snapshot.liabilities_data)
+  end
 end

--- a/app/models/plaid_account/investments/holdings_processor.rb
+++ b/app/models/plaid_account/investments/holdings_processor.rb
@@ -38,13 +38,13 @@ class PlaidAccount::Investments::HoldingsProcessor
   end
 
   private
-    attr_reader :plaid_account, :security_resolver
+  attr_reader :plaid_account, :security_resolver
 
-    def account
-      plaid_account.account
-    end
+  def account
+    plaid_account.account
+  end
 
-    def holdings
-      plaid_account.raw_investments_payload["holdings"] || []
-    end
+  def holdings
+    plaid_account.raw_investments_payload["holdings"] || []
+  end
 end

--- a/app/models/plaid_account/investments/security_resolver.rb
+++ b/app/models/plaid_account/investments/security_resolver.rb
@@ -38,56 +38,56 @@ class PlaidAccount::Investments::SecurityResolver
   end
 
   private
-    attr_reader :plaid_account, :security_cache
+  attr_reader :plaid_account, :security_cache
 
-    Response = Struct.new(:security, :cash_equivalent?, :brokerage_cash?, keyword_init: true)
+  Response = Struct.new(:security, :cash_equivalent?, :brokerage_cash?, keyword_init: true)
 
-    def securities
-      plaid_account.raw_investments_payload["securities"] || []
+  def securities
+    plaid_account.raw_investments_payload["securities"] || []
+  end
+
+  # Tries to find security, or returns the "proxy security" (common with options contracts that have underlying securities)
+  def get_plaid_security(plaid_security_id)
+    security = securities.find { |s| s["security_id"] == plaid_security_id && s["ticker_symbol"].present? }
+
+    return security if security.present?
+
+    securities.find { |s| s["proxy_security_id"] == plaid_security_id }
+  end
+
+  def report_unresolvable_security(plaid_security_id)
+    Sentry.capture_exception(UnresolvablePlaidSecurityError.new("Could not resolve Plaid security from provided data")) do |scope|
+      scope.set_context("plaid_security", {
+        plaid_security_id: plaid_security_id
+      })
     end
+  end
 
-    # Tries to find security, or returns the "proxy security" (common with options contracts that have underlying securities)
-    def get_plaid_security(plaid_security_id)
-      security = securities.find { |s| s["security_id"] == plaid_security_id && s["ticker_symbol"].present? }
+  # Plaid treats "brokerage cash" differently than us.  Internally, Maybe treats "brokerage cash"
+  # as "uninvested cash" (i.e. cash that doesn't have a corresponding Security and can be withdrawn).
+  #
+  # Plaid treats everything as a "holding" with a corresponding Security.  For example, "brokerage cash" (USD)
+  # in Plaids data model would be represented as:
+  #
+  # - A Security with ticker `CUR:USD`
+  # - A holding, linked to the `CUR:USD` Security, with an institution price of $1
+  #
+  # Internally, we store brokerage cash balance as `account.cash_balance`, NOT as a holding + security.
+  # This allows us to properly build historical cash balances and holdings values separately and accurately.
+  #
+  # These help identify these "special case" securities for various calculations.
+  #
+  def known_plaid_brokerage_cash_tickers
+    ["CUR:USD"]
+  end
 
-      return security if security.present?
+  def brokerage_cash?(plaid_security)
+    return false unless plaid_security["ticker_symbol"].present?
+    known_plaid_brokerage_cash_tickers.include?(plaid_security["ticker_symbol"])
+  end
 
-      securities.find { |s| s["proxy_security_id"] == plaid_security_id }
-    end
-
-    def report_unresolvable_security(plaid_security_id)
-      Sentry.capture_exception(UnresolvablePlaidSecurityError.new("Could not resolve Plaid security from provided data")) do |scope|
-        scope.set_context("plaid_security", {
-          plaid_security_id: plaid_security_id
-        })
-      end
-    end
-
-    # Plaid treats "brokerage cash" differently than us.  Internally, Maybe treats "brokerage cash"
-    # as "uninvested cash" (i.e. cash that doesn't have a corresponding Security and can be withdrawn).
-    #
-    # Plaid treats everything as a "holding" with a corresponding Security.  For example, "brokerage cash" (USD)
-    # in Plaids data model would be represented as:
-    #
-    # - A Security with ticker `CUR:USD`
-    # - A holding, linked to the `CUR:USD` Security, with an institution price of $1
-    #
-    # Internally, we store brokerage cash balance as `account.cash_balance`, NOT as a holding + security.
-    # This allows us to properly build historical cash balances and holdings values separately and accurately.
-    #
-    # These help identify these "special case" securities for various calculations.
-    #
-    def known_plaid_brokerage_cash_tickers
-      ["CUR:USD"]
-    end
-
-    def brokerage_cash?(plaid_security)
-      return false unless plaid_security["ticker_symbol"].present?
-      known_plaid_brokerage_cash_tickers.include?(plaid_security["ticker_symbol"])
-    end
-
-    def cash_equivalent?(plaid_security)
-      return false unless plaid_security["type"].present?
-      plaid_security["type"] == "cash" || plaid_security["is_cash_equivalent"] == true
-    end
+  def cash_equivalent?(plaid_security)
+    return false unless plaid_security["type"].present?
+    plaid_security["type"] == "cash" || plaid_security["is_cash_equivalent"] == true
+  end
 end

--- a/app/models/plaid_account/investments/transactions_processor.rb
+++ b/app/models/plaid_account/investments/transactions_processor.rb
@@ -17,91 +17,91 @@ class PlaidAccount::Investments::TransactionsProcessor
   end
 
   private
-    attr_reader :plaid_account, :security_resolver
+  attr_reader :plaid_account, :security_resolver
 
-    def account
-      plaid_account.account
-    end
+  def account
+    plaid_account.account
+  end
 
-    def cash_transaction?(transaction)
-      transaction["type"] == "cash" || transaction["type"] == "fee" || transaction["type"] == "transfer"
-    end
+  def cash_transaction?(transaction)
+    transaction["type"] == "cash" || transaction["type"] == "fee" || transaction["type"] == "transfer"
+  end
 
-    def find_or_create_trade_entry(transaction)
-      resolved_security_result = security_resolver.resolve(plaid_security_id: transaction["security_id"])
+  def find_or_create_trade_entry(transaction)
+    resolved_security_result = security_resolver.resolve(plaid_security_id: transaction["security_id"])
 
-      unless resolved_security_result.security.present?
-        Sentry.capture_exception(SecurityNotFoundError.new("Could not find security for plaid trade")) do |scope|
-          scope.set_tags(plaid_account_id: plaid_account.id)
-        end
-
-        return # We can't process a non-cash transaction without a security
+    unless resolved_security_result.security.present?
+      Sentry.capture_exception(SecurityNotFoundError.new("Could not find security for plaid trade")) do |scope|
+        scope.set_tags(plaid_account_id: plaid_account.id)
       end
 
-      entry = account.entries.find_or_initialize_by(plaid_id: transaction["investment_transaction_id"]) do |e|
-        e.entryable = Trade.new
-      end
-
-      entry.assign_attributes(
-        amount: derived_qty(transaction) * transaction["price"],
-        currency: transaction["iso_currency_code"],
-        date: transaction["date"]
-      )
-
-      entry.trade.assign_attributes(
-        security: resolved_security_result.security,
-        qty: derived_qty(transaction),
-        price: transaction["price"],
-        currency: transaction["iso_currency_code"]
-      )
-
-      entry.enrich_attribute(
-        :name,
-        transaction["name"],
-        source: "plaid"
-      )
-
-      entry.save!
+      return # We can't process a non-cash transaction without a security
     end
 
-    def find_or_create_cash_entry(transaction)
-      entry = account.entries.find_or_initialize_by(plaid_id: transaction["investment_transaction_id"]) do |e|
-        e.entryable = Transaction.new
-      end
-
-      entry.assign_attributes(
-        amount: transaction["amount"],
-        currency: transaction["iso_currency_code"],
-        date: transaction["date"]
-      )
-
-      entry.enrich_attribute(
-        :name,
-        transaction["name"],
-        source: "plaid"
-      )
-
-      entry.save!
+    entry = account.entries.find_or_initialize_by(plaid_id: transaction["investment_transaction_id"]) do |e|
+      e.entryable = Trade.new
     end
 
-    def transactions
-      plaid_account.raw_investments_payload["transactions"] || []
+    entry.assign_attributes(
+      amount: derived_qty(transaction) * transaction["price"],
+      currency: transaction["iso_currency_code"],
+      date: transaction["date"]
+    )
+
+    entry.trade.assign_attributes(
+      security: resolved_security_result.security,
+      qty: derived_qty(transaction),
+      price: transaction["price"],
+      currency: transaction["iso_currency_code"]
+    )
+
+    entry.enrich_attribute(
+      :name,
+      transaction["name"],
+      source: "plaid"
+    )
+
+    entry.save!
+  end
+
+  def find_or_create_cash_entry(transaction)
+    entry = account.entries.find_or_initialize_by(plaid_id: transaction["investment_transaction_id"]) do |e|
+      e.entryable = Transaction.new
     end
 
-    # Plaid unfortunately returns incorrect signage on some `quantity` values. They claim all "sell" transactions
-    # are negative signage, but we have found multiple instances of production data where this is not the case.
-    #
-    # This method attempts to use several Plaid data points to derive the true quantity with the correct signage.
-    def derived_qty(transaction)
-      reported_qty = transaction["quantity"]
-      abs_qty = reported_qty.abs
+    entry.assign_attributes(
+      amount: transaction["amount"],
+      currency: transaction["iso_currency_code"],
+      date: transaction["date"]
+    )
 
-      if transaction["type"] == "sell" || transaction["amount"] < 0
-        -abs_qty
-      elsif transaction["type"] == "buy" || transaction["amount"] > 0
-        abs_qty
-      else
-        reported_qty
-      end
+    entry.enrich_attribute(
+      :name,
+      transaction["name"],
+      source: "plaid"
+    )
+
+    entry.save!
+  end
+
+  def transactions
+    plaid_account.raw_investments_payload["transactions"] || []
+  end
+
+  # Plaid unfortunately returns incorrect signage on some `quantity` values. They claim all "sell" transactions
+  # are negative signage, but we have found multiple instances of production data where this is not the case.
+  #
+  # This method attempts to use several Plaid data points to derive the true quantity with the correct signage.
+  def derived_qty(transaction)
+    reported_qty = transaction["quantity"]
+    abs_qty = reported_qty.abs
+
+    if transaction["type"] == "sell" || transaction["amount"] < 0
+      -abs_qty
+    elsif transaction["type"] == "buy" || transaction["amount"] > 0
+      abs_qty
+    else
+      reported_qty
     end
+  end
 end

--- a/app/models/plaid_account/liabilities/credit_processor.rb
+++ b/app/models/plaid_account/liabilities/credit_processor.rb
@@ -13,13 +13,13 @@ class PlaidAccount::Liabilities::CreditProcessor
   end
 
   private
-    attr_reader :plaid_account
+  attr_reader :plaid_account
 
-    def account
-      plaid_account.account
-    end
+  def account
+    plaid_account.account
+  end
 
-    def credit_data
-      plaid_account.raw_liabilities_payload["credit"]
-    end
+  def credit_data
+    plaid_account.raw_liabilities_payload["credit"]
+  end
 end

--- a/app/models/plaid_account/liabilities/mortgage_processor.rb
+++ b/app/models/plaid_account/liabilities/mortgage_processor.rb
@@ -13,13 +13,13 @@ class PlaidAccount::Liabilities::MortgageProcessor
   end
 
   private
-    attr_reader :plaid_account
+  attr_reader :plaid_account
 
-    def account
-      plaid_account.account
-    end
+  def account
+    plaid_account.account
+  end
 
-    def mortgage_data
-      plaid_account.raw_liabilities_payload["mortgage"]
-    end
+  def mortgage_data
+    plaid_account.raw_liabilities_payload["mortgage"]
+  end
 end

--- a/app/models/plaid_account/liabilities/student_loan_processor.rb
+++ b/app/models/plaid_account/liabilities/student_loan_processor.rb
@@ -15,36 +15,36 @@ class PlaidAccount::Liabilities::StudentLoanProcessor
   end
 
   private
-    attr_reader :plaid_account
+  attr_reader :plaid_account
 
-    def account
-      plaid_account.account
-    end
+  def account
+    plaid_account.account
+  end
 
-    def term_months
-      return nil unless origination_date && expected_payoff_date
+  def term_months
+    return nil unless origination_date && expected_payoff_date
 
-      ((expected_payoff_date - origination_date).to_i / 30).to_i
-    end
+    ((expected_payoff_date - origination_date).to_i / 30).to_i
+  end
 
-    def origination_date
-      parse_date(student_loan_data["origination_date"])
-    end
+  def origination_date
+    parse_date(student_loan_data["origination_date"])
+  end
 
-    def expected_payoff_date
-      parse_date(student_loan_data["expected_payoff_date"])
-    end
+  def expected_payoff_date
+    parse_date(student_loan_data["expected_payoff_date"])
+  end
 
-    def parse_date(value)
-      return value if value.is_a?(Date)
-      return nil unless value.present?
+  def parse_date(value)
+    return value if value.is_a?(Date)
+    return nil unless value.present?
 
-      Date.parse(value.to_s)
-    rescue ArgumentError
-      nil
-    end
+    Date.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
 
-    def student_loan_data
-      plaid_account.raw_liabilities_payload["student"]
-    end
+  def student_loan_data
+    plaid_account.raw_liabilities_payload["student"]
+  end
 end

--- a/app/models/plaid_account/processor.rb
+++ b/app/models/plaid_account/processor.rb
@@ -19,91 +19,91 @@ class PlaidAccount::Processor
   end
 
   private
-    def family
-      plaid_account.plaid_item.family
+  def family
+    plaid_account.plaid_item.family
+  end
+
+  # Shared securities reader and resolver
+  def security_resolver
+    @security_resolver ||= PlaidAccount::Investments::SecurityResolver.new(plaid_account)
+  end
+
+  def process_account!
+    PlaidAccount.transaction do
+      account = family.accounts.find_or_initialize_by(
+        plaid_account_id: plaid_account.id
+      )
+
+      # Name and subtype are the only attributes a user can override for Plaid accounts
+      account.enrich_attributes(
+        {
+          name: plaid_account.name,
+          subtype: map_subtype(plaid_account.plaid_type, plaid_account.plaid_subtype)
+        },
+        source: "plaid"
+      )
+
+      account.assign_attributes(
+        accountable: map_accountable(plaid_account.plaid_type),
+        balance: balance_calculator.balance,
+        currency: plaid_account.currency,
+        cash_balance: balance_calculator.cash_balance
+      )
+
+      account.save!
+
+      # Create or update the current balance anchor valuation for event-sourced ledger
+      # Note: This is a partial implementation. In the future, we'll introduce HoldingValuation
+      # to properly track the holdings vs. cash breakdown, but for now we're only tracking
+      # the total balance in the current anchor. The cash_balance field on the account model
+      # is still being used for the breakdown.
+      account.set_current_balance(balance_calculator.balance)
     end
+  end
 
-    # Shared securities reader and resolver
-    def security_resolver
-      @security_resolver ||= PlaidAccount::Investments::SecurityResolver.new(plaid_account)
+  def process_transactions
+    PlaidAccount::Transactions::Processor.new(plaid_account).process
+  rescue => e
+    report_exception(e)
+  end
+
+  def process_investments
+    PlaidAccount::Investments::TransactionsProcessor.new(plaid_account, security_resolver: security_resolver).process
+    PlaidAccount::Investments::HoldingsProcessor.new(plaid_account, security_resolver: security_resolver).process
+  rescue => e
+    report_exception(e)
+  end
+
+  def process_liabilities
+    case [plaid_account.plaid_type, plaid_account.plaid_subtype]
+    when ["credit", "credit card"]
+      PlaidAccount::Liabilities::CreditProcessor.new(plaid_account).process
+    when ["loan", "mortgage"]
+      PlaidAccount::Liabilities::MortgageProcessor.new(plaid_account).process
+    when ["loan", "student"]
+      PlaidAccount::Liabilities::StudentLoanProcessor.new(plaid_account).process
     end
+  rescue => e
+    report_exception(e)
+  end
 
-    def process_account!
-      PlaidAccount.transaction do
-        account = family.accounts.find_or_initialize_by(
-          plaid_account_id: plaid_account.id
-        )
+  def balance_calculator
+    if plaid_account.plaid_type == "investment"
+      @balance_calculator ||= PlaidAccount::Investments::BalanceCalculator.new(plaid_account, security_resolver: security_resolver)
+    else
+      balance = plaid_account.current_balance || plaid_account.available_balance || 0
 
-        # Name and subtype are the only attributes a user can override for Plaid accounts
-        account.enrich_attributes(
-          {
-            name: plaid_account.name,
-            subtype: map_subtype(plaid_account.plaid_type, plaid_account.plaid_subtype)
-          },
-          source: "plaid"
-        )
-
-        account.assign_attributes(
-          accountable: map_accountable(plaid_account.plaid_type),
-          balance: balance_calculator.balance,
-          currency: plaid_account.currency,
-          cash_balance: balance_calculator.cash_balance
-        )
-
-        account.save!
-
-        # Create or update the current balance anchor valuation for event-sourced ledger
-        # Note: This is a partial implementation. In the future, we'll introduce HoldingValuation
-        # to properly track the holdings vs. cash breakdown, but for now we're only tracking
-        # the total balance in the current anchor. The cash_balance field on the account model
-        # is still being used for the breakdown.
-        account.set_current_balance(balance_calculator.balance)
-      end
+      # We don't currently distinguish "cash" vs. "non-cash" balances for non-investment accounts.
+      OpenStruct.new(
+        balance: balance,
+        cash_balance: balance
+      )
     end
+  end
 
-    def process_transactions
-      PlaidAccount::Transactions::Processor.new(plaid_account).process
-    rescue => e
-      report_exception(e)
+  def report_exception(error)
+    Sentry.capture_exception(error) do |scope|
+      scope.set_tags(plaid_account_id: plaid_account.id)
     end
-
-    def process_investments
-      PlaidAccount::Investments::TransactionsProcessor.new(plaid_account, security_resolver: security_resolver).process
-      PlaidAccount::Investments::HoldingsProcessor.new(plaid_account, security_resolver: security_resolver).process
-    rescue => e
-      report_exception(e)
-    end
-
-    def process_liabilities
-      case [plaid_account.plaid_type, plaid_account.plaid_subtype]
-      when ["credit", "credit card"]
-        PlaidAccount::Liabilities::CreditProcessor.new(plaid_account).process
-      when ["loan", "mortgage"]
-        PlaidAccount::Liabilities::MortgageProcessor.new(plaid_account).process
-      when ["loan", "student"]
-        PlaidAccount::Liabilities::StudentLoanProcessor.new(plaid_account).process
-      end
-    rescue => e
-      report_exception(e)
-    end
-
-    def balance_calculator
-      if plaid_account.plaid_type == "investment"
-        @balance_calculator ||= PlaidAccount::Investments::BalanceCalculator.new(plaid_account, security_resolver: security_resolver)
-      else
-        balance = plaid_account.current_balance || plaid_account.available_balance || 0
-
-        # We don't currently distinguish "cash" vs. "non-cash" balances for non-investment accounts.
-        OpenStruct.new(
-          balance: balance,
-          cash_balance: balance
-        )
-      end
-    end
-
-    def report_exception(error)
-      Sentry.capture_exception(error) do |scope|
-        scope.set_tags(plaid_account_id: plaid_account.id)
-      end
-    end
+  end
 end

--- a/app/models/plaid_account/transactions/category_matcher.rb
+++ b/app/models/plaid_account/transactions/category_matcher.rb
@@ -73,37 +73,37 @@ class PlaidAccount::Transactions::CategoryMatcher
   end
 
   private
-    attr_reader :user_categories
+  attr_reader :user_categories
 
-    def get_plaid_category_details(plaid_category_name)
-      detailed_plaid_categories.find { |c| c[:key] == plaid_category_name.downcase.to_sym }
-    end
+  def get_plaid_category_details(plaid_category_name)
+    detailed_plaid_categories.find { |c| c[:key] == plaid_category_name.downcase.to_sym }
+  end
 
-    def detailed_plaid_categories
-      CATEGORIES_MAP.flat_map do |parent_key, parent_data|
-        parent_data[:detailed_categories].map do |child_key, child_data|
-          {
-            key: child_key,
-            classification: child_data[:classification],
-            aliases: child_data[:aliases],
-            parent_key: parent_key,
-            parent_aliases: parent_data[:aliases]
-          }
-        end
-      end
-    end
-
-    def normalized_user_categories
-      user_categories.map do |user_category|
+  def detailed_plaid_categories
+    CATEGORIES_MAP.flat_map do |parent_key, parent_data|
+      parent_data[:detailed_categories].map do |child_key, child_data|
         {
-          id: user_category.id,
-          classification: user_category.classification,
-          name: normalize_user_category_name(user_category.name)
+          key: child_key,
+          classification: child_data[:classification],
+          aliases: child_data[:aliases],
+          parent_key: parent_key,
+          parent_aliases: parent_data[:aliases]
         }
       end
     end
+  end
 
-    def normalize_user_category_name(name)
-      name.to_s.downcase.gsub(/[^a-z0-9]/, " ").strip
+  def normalized_user_categories
+    user_categories.map do |user_category|
+      {
+        id: user_category.id,
+        classification: user_category.classification,
+        name: normalize_user_category_name(user_category.name)
+      }
     end
+  end
+
+  def normalize_user_category_name(name)
+    name.to_s.downcase.gsub(/[^a-z0-9]/, " ").strip
+  end
 end

--- a/app/models/plaid_account/transactions/processor.rb
+++ b/app/models/plaid_account/transactions/processor.rb
@@ -22,39 +22,39 @@ class PlaidAccount::Transactions::Processor
   end
 
   private
-    attr_reader :plaid_account
+  attr_reader :plaid_account
 
-    def category_matcher
-      @category_matcher ||= PlaidAccount::Transactions::CategoryMatcher.new(family_categories)
-    end
+  def category_matcher
+    @category_matcher ||= PlaidAccount::Transactions::CategoryMatcher.new(family_categories)
+  end
 
-    def family_categories
-      @family_categories ||= begin
-        if account.family.categories.none?
-          account.family.categories.bootstrap!
-        end
-
-        account.family.categories
+  def family_categories
+    @family_categories ||= begin
+      if account.family.categories.none?
+        account.family.categories.bootstrap!
       end
-    end
 
-    def account
-      plaid_account.account
+      account.family.categories
     end
+  end
 
-    def remove_plaid_transaction(raw_transaction)
-      account.entries.find_by(plaid_id: raw_transaction["transaction_id"])&.destroy
-    end
+  def account
+    plaid_account.account
+  end
 
-    # Since we find_or_create_by transactions, we don't need a distinction between added/modified
-    def modified_transactions
-      modified = plaid_account.raw_transactions_payload["modified"] || []
-      added = plaid_account.raw_transactions_payload["added"] || []
+  def remove_plaid_transaction(raw_transaction)
+    account.entries.find_by(plaid_id: raw_transaction["transaction_id"])&.destroy
+  end
 
-      modified + added
-    end
+  # Since we find_or_create_by transactions, we don't need a distinction between added/modified
+  def modified_transactions
+    modified = plaid_account.raw_transactions_payload["modified"] || []
+    added = plaid_account.raw_transactions_payload["added"] || []
 
-    def removed_transactions
-      plaid_account.raw_transactions_payload["removed"] || []
-    end
+    modified + added
+  end
+
+  def removed_transactions
+    plaid_account.raw_transactions_payload["removed"] || []
+  end
 end

--- a/app/models/plaid_entry/processor.rb
+++ b/app/models/plaid_entry/processor.rb
@@ -47,49 +47,49 @@ class PlaidEntry::Processor
   end
 
   private
-    attr_reader :plaid_transaction, :plaid_account, :category_matcher
+  attr_reader :plaid_transaction, :plaid_account, :category_matcher
 
-    def account
-      plaid_account.account
+  def account
+    plaid_account.account
+  end
+
+  def plaid_id
+    plaid_transaction["transaction_id"]
+  end
+
+  def name
+    plaid_transaction["merchant_name"] || plaid_transaction["original_description"]
+  end
+
+  def amount
+    plaid_transaction["amount"]
+  end
+
+  def currency
+    plaid_transaction["iso_currency_code"]
+  end
+
+  def date
+    plaid_transaction["date"]
+  end
+
+  def detailed_category
+    plaid_transaction.dig("personal_finance_category", "detailed")
+  end
+
+  def merchant
+    merchant_id = plaid_transaction["merchant_entity_id"]
+    merchant_name = plaid_transaction["merchant_name"]
+
+    return nil unless merchant_id.present? && merchant_name.present?
+
+    ProviderMerchant.find_or_create_by!(
+      source: "plaid",
+      name: merchant_name,
+    ) do |m|
+      m.provider_merchant_id = merchant_id
+      m.website_url = plaid_transaction["website"]
+      m.logo_url = plaid_transaction["logo_url"]
     end
-
-    def plaid_id
-      plaid_transaction["transaction_id"]
-    end
-
-    def name
-      plaid_transaction["merchant_name"] || plaid_transaction["original_description"]
-    end
-
-    def amount
-      plaid_transaction["amount"]
-    end
-
-    def currency
-      plaid_transaction["iso_currency_code"]
-    end
-
-    def date
-      plaid_transaction["date"]
-    end
-
-    def detailed_category
-      plaid_transaction.dig("personal_finance_category", "detailed")
-    end
-
-    def merchant
-      merchant_id = plaid_transaction["merchant_entity_id"]
-      merchant_name = plaid_transaction["merchant_name"]
-
-      return nil unless merchant_id.present? && merchant_name.present?
-
-      ProviderMerchant.find_or_create_by!(
-        source: "plaid",
-        name: merchant_name,
-      ) do |m|
-        m.provider_merchant_id = merchant_id
-        m.website_url = plaid_transaction["website"]
-        m.logo_url = plaid_transaction["logo_url"]
-      end
-    end
+  end
 end

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -98,23 +98,23 @@ class PlaidItem < ApplicationRecord
   end
 
   private
-    def remove_plaid_item
-      plaid_provider.remove_item(access_token)
-    rescue Plaid::ApiError => e
-      json_response = JSON.parse(e.response_body)
+  def remove_plaid_item
+    plaid_provider.remove_item(access_token)
+  rescue Plaid::ApiError => e
+    json_response = JSON.parse(e.response_body)
 
-      # If the item is not found, that means it was already deleted by the user on their
-      # Plaid portal OR by Plaid support.  Either way, we're not being billed, so continue
-      # with the deletion of our internal record.
-      unless json_response["error_code"] == "ITEM_NOT_FOUND"
-        raise e
-      end
+    # If the item is not found, that means it was already deleted by the user on their
+    # Plaid portal OR by Plaid support.  Either way, we're not being billed, so continue
+    # with the deletion of our internal record.
+    unless json_response["error_code"] == "ITEM_NOT_FOUND"
+      raise e
     end
+  end
 
-    # Plaid returns mutually exclusive arrays here.  If the item has made a request for a product,
-    # it is put in the billed_products array.  If it is supported, but not yet used, it goes in the
-    # available_products array.
-    def supported_products
-      available_products + billed_products
-    end
+  # Plaid returns mutually exclusive arrays here.  If the item has made a request for a product,
+  # it is put in the billed_products array.  If it is supported, but not yet used, it goes in the
+  # available_products array.
+  def supported_products
+    available_products + billed_products
+  end
 end

--- a/app/models/plaid_item/accounts_snapshot.rb
+++ b/app/models/plaid_item/accounts_snapshot.rb
@@ -26,80 +26,80 @@ class PlaidItem::AccountsSnapshot
   end
 
   private
-    attr_reader :plaid_item, :plaid_provider
+  attr_reader :plaid_item, :plaid_provider
 
-    TransactionsData = Data.define(:added, :modified, :removed)
-    LiabilitiesData = Data.define(:credit, :mortgage, :student)
-    InvestmentsData = Data.define(:transactions, :holdings, :securities)
-    AccountData = Data.define(:account_data, :transactions_data, :investments_data, :liabilities_data)
+  TransactionsData = Data.define(:added, :modified, :removed)
+  LiabilitiesData = Data.define(:credit, :mortgage, :student)
+  InvestmentsData = Data.define(:transactions, :holdings, :securities)
+  AccountData = Data.define(:account_data, :transactions_data, :investments_data, :liabilities_data)
 
-    def account_scoped_transactions_data(account_id)
-      return nil unless transactions_data
+  def account_scoped_transactions_data(account_id)
+    return nil unless transactions_data
 
-      TransactionsData.new(
-        added: transactions_data.added.select { |t| t.account_id == account_id },
-        modified: transactions_data.modified.select { |t| t.account_id == account_id },
-        removed: transactions_data.removed.select { |t| t.account_id == account_id }
-      )
+    TransactionsData.new(
+      added: transactions_data.added.select { |t| t.account_id == account_id },
+      modified: transactions_data.modified.select { |t| t.account_id == account_id },
+      removed: transactions_data.removed.select { |t| t.account_id == account_id }
+    )
+  end
+
+  def account_scoped_investments_data(account_id)
+    return nil unless investments_data
+
+    transactions = investments_data.transactions.select { |t| t.account_id == account_id }
+    holdings = investments_data.holdings.select { |h| h.account_id == account_id }
+    securities = transactions.count > 0 && holdings.count > 0 ? investments_data.securities : []
+
+    InvestmentsData.new(
+      transactions: transactions,
+      holdings: holdings,
+      securities: securities
+    )
+  end
+
+  def account_scoped_liabilities_data(account_id)
+    return nil unless liabilities_data
+
+    LiabilitiesData.new(
+      credit: liabilities_data.credit&.find { |c| c.account_id == account_id },
+      mortgage: liabilities_data.mortgage&.find { |m| m.account_id == account_id },
+      student: liabilities_data.student&.find { |s| s.account_id == account_id }
+    )
+  end
+
+  def can_fetch_transactions?
+    plaid_item.supports_product?("transactions") && accounts.any?
+  end
+
+  def transactions_data
+    return nil unless can_fetch_transactions?
+
+    @transactions_data ||= plaid_provider.get_transactions(
+      plaid_item.access_token,
+      next_cursor: plaid_item.next_cursor
+    )
+  end
+
+  def can_fetch_investments?
+    plaid_item.supports_product?("investments") &&
+    accounts.any? { |a| a.type == "investment" }
+  end
+
+  def investments_data
+    return nil unless can_fetch_investments?
+    @investments_data ||= plaid_provider.get_item_investments(plaid_item.access_token)
+  end
+
+  def can_fetch_liabilities?
+    plaid_item.supports_product?("liabilities") &&
+    accounts.any? do |a|
+      a.type == "credit" && a.subtype == "credit card" ||
+      a.type == "loan" && (a.subtype == "mortgage" || a.subtype == "student")
     end
+  end
 
-    def account_scoped_investments_data(account_id)
-      return nil unless investments_data
-
-      transactions = investments_data.transactions.select { |t| t.account_id == account_id }
-      holdings = investments_data.holdings.select { |h| h.account_id == account_id }
-      securities = transactions.count > 0 && holdings.count > 0 ? investments_data.securities : []
-
-      InvestmentsData.new(
-        transactions: transactions,
-        holdings: holdings,
-        securities: securities
-      )
-    end
-
-    def account_scoped_liabilities_data(account_id)
-      return nil unless liabilities_data
-
-      LiabilitiesData.new(
-        credit: liabilities_data.credit&.find { |c| c.account_id == account_id },
-        mortgage: liabilities_data.mortgage&.find { |m| m.account_id == account_id },
-        student: liabilities_data.student&.find { |s| s.account_id == account_id }
-      )
-    end
-
-    def can_fetch_transactions?
-      plaid_item.supports_product?("transactions") && accounts.any?
-    end
-
-    def transactions_data
-      return nil unless can_fetch_transactions?
-
-      @transactions_data ||= plaid_provider.get_transactions(
-        plaid_item.access_token,
-        next_cursor: plaid_item.next_cursor
-      )
-    end
-
-    def can_fetch_investments?
-      plaid_item.supports_product?("investments") &&
-      accounts.any? { |a| a.type == "investment" }
-    end
-
-    def investments_data
-      return nil unless can_fetch_investments?
-      @investments_data ||= plaid_provider.get_item_investments(plaid_item.access_token)
-    end
-
-    def can_fetch_liabilities?
-      plaid_item.supports_product?("liabilities") &&
-      accounts.any? do |a|
-        a.type == "credit" && a.subtype == "credit card" ||
-        a.type == "loan" && (a.subtype == "mortgage" || a.subtype == "student")
-      end
-    end
-
-    def liabilities_data
-      return nil unless can_fetch_liabilities?
-      @liabilities_data ||= plaid_provider.get_item_liabilities(plaid_item.access_token)
-    end
+  def liabilities_data
+    return nil unless can_fetch_liabilities?
+    @liabilities_data ||= plaid_provider.get_item_liabilities(plaid_item.access_token)
+  end
 end

--- a/app/models/plaid_item/importer.rb
+++ b/app/models/plaid_item/importer.rb
@@ -12,46 +12,46 @@ class PlaidItem::Importer
   end
 
   private
-    attr_reader :plaid_item, :plaid_provider
+  attr_reader :plaid_item, :plaid_provider
 
-    # All errors that should halt the import should be re-raised after handling
-    # These errors will propagate up to the Sync record and mark it as failed.
-    def handle_plaid_error(error)
-      error_body = JSON.parse(error.response_body)
+  # All errors that should halt the import should be re-raised after handling
+  # These errors will propagate up to the Sync record and mark it as failed.
+  def handle_plaid_error(error)
+    error_body = JSON.parse(error.response_body)
 
-      case error_body["error_code"]
-      when "ITEM_LOGIN_REQUIRED"
-        plaid_item.update!(status: :requires_update)
-      else
-        raise error
+    case error_body["error_code"]
+    when "ITEM_LOGIN_REQUIRED"
+      plaid_item.update!(status: :requires_update)
+    else
+      raise error
+    end
+  end
+
+  def fetch_and_import_item_data
+    item_data = plaid_provider.get_item(plaid_item.access_token).item
+    institution_data = plaid_provider.get_institution(item_data.institution_id).institution
+
+    plaid_item.upsert_plaid_snapshot!(item_data)
+    plaid_item.upsert_plaid_institution_snapshot!(institution_data)
+  end
+
+  def fetch_and_import_accounts_data
+    snapshot = PlaidItem::AccountsSnapshot.new(plaid_item, plaid_provider: plaid_provider)
+
+    PlaidItem.transaction do
+      snapshot.accounts.each do |raw_account|
+        plaid_account = plaid_item.plaid_accounts.find_or_initialize_by(
+          plaid_id: raw_account.account_id
+        )
+
+        PlaidAccount::Importer.new(
+          plaid_account,
+          account_snapshot: snapshot.get_account_data(raw_account.account_id)
+        ).import
       end
+
+      # Once we know all data has been imported, save the cursor to avoid re-fetching the same data next time
+      plaid_item.update!(next_cursor: snapshot.transactions_cursor)
     end
-
-    def fetch_and_import_item_data
-      item_data = plaid_provider.get_item(plaid_item.access_token).item
-      institution_data = plaid_provider.get_institution(item_data.institution_id).institution
-
-      plaid_item.upsert_plaid_snapshot!(item_data)
-      plaid_item.upsert_plaid_institution_snapshot!(institution_data)
-    end
-
-    def fetch_and_import_accounts_data
-      snapshot = PlaidItem::AccountsSnapshot.new(plaid_item, plaid_provider: plaid_provider)
-
-      PlaidItem.transaction do
-        snapshot.accounts.each do |raw_account|
-          plaid_account = plaid_item.plaid_accounts.find_or_initialize_by(
-            plaid_id: raw_account.account_id
-          )
-
-          PlaidAccount::Importer.new(
-            plaid_account,
-            account_snapshot: snapshot.get_account_data(raw_account.account_id)
-          ).import
-        end
-
-        # Once we know all data has been imported, save the cursor to avoid re-fetching the same data next time
-        plaid_item.update!(next_cursor: snapshot.transactions_cursor)
-      end
-    end
+  end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -51,7 +51,7 @@ class Property < ApplicationRecord
   end
 
   private
-    def first_valuation_amount
-      account.entries.valuations.order(:date).first&.amount_money || account.balance_money
-    end
+  def first_valuation_amount
+    account.entries.valuations.order(:date).first&.amount_money || account.balance_money
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,40 +18,40 @@ class Provider
   end
 
   private
-    PaginatedData = Data.define(:paginated, :first_page, :total_pages)
-    UsageData = Data.define(:used, :limit, :utilization, :plan)
+  PaginatedData = Data.define(:paginated, :first_page, :total_pages)
+  UsageData = Data.define(:used, :limit, :utilization, :plan)
 
-    def with_provider_response(error_transformer: nil, &block)
-      data = yield
+  def with_provider_response(error_transformer: nil, &block)
+    data = yield
 
-      Response.new(
-        success?: true,
-        data: data,
-        error: nil,
-      )
-    rescue => error
-      transformed_error = if error_transformer
-        error_transformer.call(error)
-      else
-        default_error_transformer(error)
-      end
-
-      Response.new(
-        success?: false,
-        data: nil,
-        error: transformed_error
-      )
+    Response.new(
+      success?: true,
+      data: data,
+      error: nil,
+    )
+  rescue => error
+    transformed_error = if error_transformer
+      error_transformer.call(error)
+    else
+      default_error_transformer(error)
     end
 
-    # Override to set class-level error transformation for methods using `with_provider_response`
-    def default_error_transformer(error)
-      if error.is_a?(Faraday::Error)
-        self.class::Error.new(
-          error.message,
-          details: error.response&.dig(:body),
-        )
-      else
-        self.class::Error.new(error.message)
-      end
+    Response.new(
+      success?: false,
+      data: nil,
+      error: transformed_error
+    )
+  end
+
+  # Override to set class-level error transformation for methods using `with_provider_response`
+  def default_error_transformer(error)
+    if error.is_a?(Faraday::Error)
+      self.class::Error.new(
+        error.message,
+        details: error.response&.dig(:body),
+      )
+    else
+      self.class::Error.new(error.message)
     end
+  end
 end

--- a/app/models/provider/github.rb
+++ b/app/models/provider/github.rb
@@ -31,7 +31,7 @@ class Provider::Github
   end
 
   private
-    def repo
-      "#{owner}/#{name}"
-    end
+  def repo
+    "#{owner}/#{name}"
+  end
 end

--- a/app/models/provider/openai.rb
+++ b/app/models/provider/openai.rb
@@ -82,5 +82,5 @@ class Provider::Openai < Provider
   end
 
   private
-    attr_reader :client
+  attr_reader :client
 end

--- a/app/models/provider/openai/auto_categorizer.rb
+++ b/app/models/provider/openai/auto_categorizer.rb
@@ -26,63 +26,63 @@ class Provider::Openai::AutoCategorizer
   end
 
   private
-    attr_reader :client, :transactions, :user_categories
+  attr_reader :client, :transactions, :user_categories
 
-    AutoCategorization = Provider::LlmConcept::AutoCategorization
+  AutoCategorization = Provider::LlmConcept::AutoCategorization
 
-    def build_response(categorizations)
-      categorizations.map do |categorization|
-        AutoCategorization.new(
-          transaction_id: categorization.dig("transaction_id"),
-          category_name: normalize_category_name(categorization.dig("category_name")),
-        )
-      end
+  def build_response(categorizations)
+    categorizations.map do |categorization|
+      AutoCategorization.new(
+        transaction_id: categorization.dig("transaction_id"),
+        category_name: normalize_category_name(categorization.dig("category_name")),
+      )
     end
+  end
 
-    def normalize_category_name(category_name)
-      return nil if category_name == "null"
+  def normalize_category_name(category_name)
+    return nil if category_name == "null"
 
-      category_name
-    end
+    category_name
+  end
 
-    def extract_categorizations(response)
-      response_json = JSON.parse(response.dig("output")[0].dig("content")[0].dig("text"))
-      response_json.dig("categorizations")
-    end
+  def extract_categorizations(response)
+    response_json = JSON.parse(response.dig("output")[0].dig("content")[0].dig("text"))
+    response_json.dig("categorizations")
+  end
 
-    def json_schema
-      {
-        type: "object",
-        properties: {
-          categorizations: {
-            type: "array",
-            description: "An array of auto-categorizations for each transaction",
-            items: {
-              type: "object",
-              properties: {
-                transaction_id: {
-                  type: "string",
-                  description: "The internal ID of the original transaction",
-                  enum: transactions.map { |t| t[:id] }
-                },
-                category_name: {
-                  type: "string",
-                  description: "The matched category name of the transaction, or null if no match",
-                  enum: [*user_categories.map { |c| c[:name] }, "null"]
-                }
+  def json_schema
+    {
+      type: "object",
+      properties: {
+        categorizations: {
+          type: "array",
+          description: "An array of auto-categorizations for each transaction",
+          items: {
+            type: "object",
+            properties: {
+              transaction_id: {
+                type: "string",
+                description: "The internal ID of the original transaction",
+                enum: transactions.map { |t| t[:id] }
               },
-              required: ["transaction_id", "category_name"],
-              additionalProperties: false
-            }
+              category_name: {
+                type: "string",
+                description: "The matched category name of the transaction, or null if no match",
+                enum: [*user_categories.map { |c| c[:name] }, "null"]
+              }
+            },
+            required: ["transaction_id", "category_name"],
+            additionalProperties: false
           }
-        },
-        required: ["categorizations"],
-        additionalProperties: false
-      }
-    end
+        }
+      },
+      required: ["categorizations"],
+      additionalProperties: false
+    }
+  end
 
-    def developer_message
-      <<~MESSAGE.strip_heredoc
+  def developer_message
+    <<~MESSAGE.strip_heredoc
         Here are the user's available categories in JSON format:
 
         ```json
@@ -95,10 +95,10 @@ class Provider::Openai::AutoCategorizer
         #{transactions.to_json}
         ```
       MESSAGE
-    end
+  end
 
-    def instructions
-      <<~INSTRUCTIONS.strip_heredoc
+  def instructions
+    <<~INSTRUCTIONS.strip_heredoc
         You are an assistant to a consumer personal finance app.  You will be provided a list
         of the user's transactions and a list of the user's categories.  Your job is to auto-categorize
         each transaction.
@@ -116,5 +116,5 @@ class Provider::Openai::AutoCategorizer
           - Note: "hint" comes from 3rd party aggregators and typically represents a category name that
             may or may not match any of the user-supplied categories
       INSTRUCTIONS
-    end
+  end
 end

--- a/app/models/provider/openai/auto_merchant_detector.rb
+++ b/app/models/provider/openai/auto_merchant_detector.rb
@@ -26,67 +26,67 @@ class Provider::Openai::AutoMerchantDetector
   end
 
   private
-    attr_reader :client, :transactions, :user_merchants
+  attr_reader :client, :transactions, :user_merchants
 
-    AutoDetectedMerchant = Provider::LlmConcept::AutoDetectedMerchant
+  AutoDetectedMerchant = Provider::LlmConcept::AutoDetectedMerchant
 
-    def build_response(categorizations)
-      categorizations.map do |categorization|
-        AutoDetectedMerchant.new(
-          transaction_id: categorization.dig("transaction_id"),
-          business_name: normalize_ai_value(categorization.dig("business_name")),
-          business_url: normalize_ai_value(categorization.dig("business_url")),
-        )
-      end
+  def build_response(categorizations)
+    categorizations.map do |categorization|
+      AutoDetectedMerchant.new(
+        transaction_id: categorization.dig("transaction_id"),
+        business_name: normalize_ai_value(categorization.dig("business_name")),
+        business_url: normalize_ai_value(categorization.dig("business_url")),
+      )
     end
+  end
 
-    def normalize_ai_value(ai_value)
-      return nil if ai_value == "null"
+  def normalize_ai_value(ai_value)
+    return nil if ai_value == "null"
 
-      ai_value
-    end
+    ai_value
+  end
 
-    def extract_categorizations(response)
-      response_json = JSON.parse(response.dig("output")[0].dig("content")[0].dig("text"))
-      response_json.dig("merchants")
-    end
+  def extract_categorizations(response)
+    response_json = JSON.parse(response.dig("output")[0].dig("content")[0].dig("text"))
+    response_json.dig("merchants")
+  end
 
-    def json_schema
-      {
-        type: "object",
-        properties: {
-          merchants: {
-            type: "array",
-            description: "An array of auto-detected merchant businesses for each transaction",
-            items: {
-              type: "object",
-              properties: {
-                transaction_id: {
-                  type: "string",
-                  description: "The internal ID of the original transaction",
-                  enum: transactions.map { |t| t[:id] }
-                },
-                business_name: {
-                  type: ["string", "null"],
-                  description: "The detected business name of the transaction, or `null` if uncertain"
-                },
-                business_url: {
-                  type: ["string", "null"],
-                  description: "The URL of the detected business, or `null` if uncertain"
-                }
+  def json_schema
+    {
+      type: "object",
+      properties: {
+        merchants: {
+          type: "array",
+          description: "An array of auto-detected merchant businesses for each transaction",
+          items: {
+            type: "object",
+            properties: {
+              transaction_id: {
+                type: "string",
+                description: "The internal ID of the original transaction",
+                enum: transactions.map { |t| t[:id] }
               },
-              required: ["transaction_id", "business_name", "business_url"],
-              additionalProperties: false
-            }
+              business_name: {
+                type: ["string", "null"],
+                description: "The detected business name of the transaction, or `null` if uncertain"
+              },
+              business_url: {
+                type: ["string", "null"],
+                description: "The URL of the detected business, or `null` if uncertain"
+              }
+            },
+            required: ["transaction_id", "business_name", "business_url"],
+            additionalProperties: false
           }
-        },
-        required: ["merchants"],
-        additionalProperties: false
-      }
-    end
+        }
+      },
+      required: ["merchants"],
+      additionalProperties: false
+    }
+  end
 
-    def developer_message
-      <<~MESSAGE.strip_heredoc
+  def developer_message
+    <<~MESSAGE.strip_heredoc
         Here are the user's available merchants in JSON format:
 
         ```json
@@ -101,10 +101,10 @@ class Provider::Openai::AutoMerchantDetector
 
         Return "null" if you are not 80%+ confident in your answer.
       MESSAGE
-    end
+  end
 
-    def instructions
-      <<~INSTRUCTIONS.strip_heredoc
+  def instructions
+    <<~INSTRUCTIONS.strip_heredoc
         You are an assistant to a consumer personal finance app.
 
         Closely follow ALL the rules below while auto-detecting business names and website URLs:
@@ -142,5 +142,5 @@ class Provider::Openai::AutoMerchantDetector
         - business_url: null
         ```
       INSTRUCTIONS
-    end
+  end
 end

--- a/app/models/provider/openai/chat_config.rb
+++ b/app/models/provider/openai/chat_config.rb
@@ -32,5 +32,5 @@ class Provider::Openai::ChatConfig
   end
 
   private
-    attr_reader :functions, :function_results
+  attr_reader :functions, :function_results
 end

--- a/app/models/provider/openai/chat_parser.rb
+++ b/app/models/provider/openai/chat_parser.rb
@@ -15,45 +15,45 @@ class Provider::Openai::ChatParser
   end
 
   private
-    attr_reader :object
+  attr_reader :object
 
-    ChatResponse = Provider::LlmConcept::ChatResponse
-    ChatMessage = Provider::LlmConcept::ChatMessage
-    ChatFunctionRequest = Provider::LlmConcept::ChatFunctionRequest
+  ChatResponse = Provider::LlmConcept::ChatResponse
+  ChatMessage = Provider::LlmConcept::ChatMessage
+  ChatFunctionRequest = Provider::LlmConcept::ChatFunctionRequest
 
-    def response_id
-      object.dig("id")
+  def response_id
+    object.dig("id")
+  end
+
+  def response_model
+    object.dig("model")
+  end
+
+  def messages
+    message_items = object.dig("output").filter { |item| item.dig("type") == "message" }
+
+    message_items.map do |message_item|
+      ChatMessage.new(
+        id: message_item.dig("id"),
+        output_text: message_item.dig("content").map do |content|
+          text = content.dig("text")
+          refusal = content.dig("refusal")
+          text || refusal
+        end.flatten.join("\n")
+      )
     end
+  end
 
-    def response_model
-      object.dig("model")
+  def function_requests
+    function_items = object.dig("output").filter { |item| item.dig("type") == "function_call" }
+
+    function_items.map do |function_item|
+      ChatFunctionRequest.new(
+        id: function_item.dig("id"),
+        call_id: function_item.dig("call_id"),
+        function_name: function_item.dig("name"),
+        function_args: function_item.dig("arguments")
+      )
     end
-
-    def messages
-      message_items = object.dig("output").filter { |item| item.dig("type") == "message" }
-
-      message_items.map do |message_item|
-        ChatMessage.new(
-          id: message_item.dig("id"),
-          output_text: message_item.dig("content").map do |content|
-            text = content.dig("text")
-            refusal = content.dig("refusal")
-            text || refusal
-          end.flatten.join("\n")
-        )
-      end
-    end
-
-    def function_requests
-      function_items = object.dig("output").filter { |item| item.dig("type") == "function_call" }
-
-      function_items.map do |function_item|
-        ChatFunctionRequest.new(
-          id: function_item.dig("id"),
-          call_id: function_item.dig("call_id"),
-          function_name: function_item.dig("name"),
-          function_args: function_item.dig("arguments")
-        )
-      end
-    end
+  end
 end

--- a/app/models/provider/openai/chat_stream_parser.rb
+++ b/app/models/provider/openai/chat_stream_parser.rb
@@ -18,11 +18,11 @@ class Provider::Openai::ChatStreamParser
   end
 
   private
-    attr_reader :object
+  attr_reader :object
 
-    Chunk = Provider::LlmConcept::ChatStreamChunk
+  Chunk = Provider::LlmConcept::ChatStreamChunk
 
-    def parse_response(response)
-      Provider::Openai::ChatParser.new(response).parsed
-    end
+  def parse_response(response)
+    Provider::Openai::ChatParser.new(response).parsed
+  end
 end

--- a/app/models/provider/plaid_sandbox.rb
+++ b/app/models/provider/plaid_sandbox.rb
@@ -37,16 +37,16 @@ class Provider::PlaidSandbox < Provider::Plaid
   end
 
   private
-    def create_client
-      raise "Plaid sandbox is not supported in production" if Rails.env.production?
+  def create_client
+    raise "Plaid sandbox is not supported in production" if Rails.env.production?
 
-      api_client = Plaid::ApiClient.new(
-        Rails.application.config.plaid_eu
-      )
+    api_client = Plaid::ApiClient.new(
+      Rails.application.config.plaid_eu
+    )
 
-      # Force sandbox environment for PlaidSandbox regardless of Rails config
-      api_client.config.server_index = Plaid::Configuration::Environment["sandbox"]
+    # Force sandbox environment for PlaidSandbox regardless of Rails config
+    api_client.config.server_index = Plaid::Configuration::Environment["sandbox"]
 
-      Plaid::PlaidApi.new(api_client)
-    end
+    Plaid::PlaidApi.new(api_client)
+  end
 end

--- a/app/models/provider/registry.rb
+++ b/app/models/provider/registry.rb
@@ -23,50 +23,50 @@ class Provider::Registry
     end
 
     private
-      def stripe
-        secret_key = ENV["STRIPE_SECRET_KEY"]
-        webhook_secret = ENV["STRIPE_WEBHOOK_SECRET"]
+    def stripe
+      secret_key = ENV["STRIPE_SECRET_KEY"]
+      webhook_secret = ENV["STRIPE_WEBHOOK_SECRET"]
 
-        return nil unless secret_key.present? && webhook_secret.present?
+      return nil unless secret_key.present? && webhook_secret.present?
 
-        Provider::Stripe.new(secret_key:, webhook_secret:)
-      end
+      Provider::Stripe.new(secret_key:, webhook_secret:)
+    end
 
-      def synth
-        api_key = ENV.fetch("SYNTH_API_KEY", Setting.synth_api_key)
+    def synth
+      api_key = ENV.fetch("SYNTH_API_KEY", Setting.synth_api_key)
 
-        return nil unless api_key.present?
+      return nil unless api_key.present?
 
-        Provider::Synth.new(api_key)
-      end
+      Provider::Synth.new(api_key)
+    end
 
-      def plaid_us
-        config = Rails.application.config.plaid
+    def plaid_us
+      config = Rails.application.config.plaid
 
-        return nil unless config.present?
+      return nil unless config.present?
 
-        Provider::Plaid.new(config, region: :us)
-      end
+      Provider::Plaid.new(config, region: :us)
+    end
 
-      def plaid_eu
-        config = Rails.application.config.plaid_eu
+    def plaid_eu
+      config = Rails.application.config.plaid_eu
 
-        return nil unless config.present?
+      return nil unless config.present?
 
-        Provider::Plaid.new(config, region: :eu)
-      end
+      Provider::Plaid.new(config, region: :eu)
+    end
 
-      def github
-        Provider::Github.new
-      end
+    def github
+      Provider::Github.new
+    end
 
-      def openai
-        access_token = ENV.fetch("OPENAI_ACCESS_TOKEN", Setting.openai_access_token)
+    def openai
+      access_token = ENV.fetch("OPENAI_ACCESS_TOKEN", Setting.openai_access_token)
 
-        return nil unless access_token.present?
+      return nil unless access_token.present?
 
-        Provider::Openai.new(access_token)
-      end
+      Provider::Openai.new(access_token)
+    end
   end
 
   def initialize(concept)
@@ -87,18 +87,18 @@ class Provider::Registry
   end
 
   private
-    attr_reader :concept
+  attr_reader :concept
 
-    def available_providers
-      case concept
-      when :exchange_rates
-        %i[synth]
-      when :securities
-        %i[synth]
-      when :llm
-        %i[openai]
-      else
-        %i[synth plaid_us plaid_eu github openai]
-      end
+  def available_providers
+    case concept
+    when :exchange_rates
+      %i[synth]
+    when :securities
+      %i[synth]
+    when :llm
+      %i[openai]
+    else
+      %i[synth plaid_us plaid_eu github openai]
     end
+  end
 end

--- a/app/models/provider/stripe.rb
+++ b/app/models/provider/stripe.rb
@@ -68,21 +68,21 @@ class Provider::Stripe
   end
 
   private
-    attr_reader :client, :webhook_secret
+  attr_reader :client, :webhook_secret
 
-    NewCheckoutSession = Data.define(:url, :customer_id)
-    CheckoutSessionResult = Data.define(:success?, :subscription_id)
+  NewCheckoutSession = Data.define(:url, :customer_id)
+  CheckoutSessionResult = Data.define(:success?, :subscription_id)
 
-    def price_id_for(plan)
-      prices = {
-        monthly: ENV["STRIPE_MONTHLY_PRICE_ID"],
-        annual: ENV["STRIPE_ANNUAL_PRICE_ID"]
-      }
+  def price_id_for(plan)
+    prices = {
+      monthly: ENV["STRIPE_MONTHLY_PRICE_ID"],
+      annual: ENV["STRIPE_ANNUAL_PRICE_ID"]
+    }
 
-      prices[plan.to_sym || :monthly]
-    end
+    prices[plan.to_sym || :monthly]
+  end
 
-    def retrieve_event(event_id)
-      client.v1.events.retrieve(event_id)
-    end
+  def retrieve_event(event_id)
+    client.v1.events.retrieve(event_id)
+  end
 end

--- a/app/models/provider/stripe/event_processor.rb
+++ b/app/models/provider/stripe/event_processor.rb
@@ -8,9 +8,9 @@ class Provider::Stripe::EventProcessor
   end
 
   private
-    attr_reader :event
+  attr_reader :event
 
-    def event_data
-      event.data.object
-    end
+  def event_data
+    event.data.object
+  end
 end

--- a/app/models/provider/stripe/subscription_event_processor.rb
+++ b/app/models/provider/stripe/subscription_event_processor.rb
@@ -15,15 +15,15 @@ class Provider::Stripe::SubscriptionEventProcessor < Provider::Stripe::EventProc
   end
 
   private
-    def family
-      Family.find_by(stripe_customer_id: subscription.customer)
-    end
+  def family
+    Family.find_by(stripe_customer_id: subscription.customer)
+  end
 
-    def subscription_details
-      event_data.items.data.first
-    end
+  def subscription_details
+    event_data.items.data.first
+  end
 
-    def subscription
-      event_data
-    end
+  def subscription
+    event_data
+  end
 end

--- a/app/models/rule/action_executor.rb
+++ b/app/models/rule/action_executor.rb
@@ -35,9 +35,9 @@ class Rule::ActionExecutor
   end
 
   private
-    attr_reader :rule
+  attr_reader :rule
 
-    def family
-      rule.family
-    end
+  def family
+    rule.family
+  end
 end

--- a/app/models/rule/condition.rb
+++ b/app/models/rule/condition.rb
@@ -60,15 +60,15 @@ class Rule::Condition < ApplicationRecord
   end
 
   private
-    def build_compound_scope(scope)
-      if operator == "or"
-        combined_scope = sub_conditions
-          .map { |sub| sub.apply(scope) }
-          .reduce { |acc, s| acc.or(s) }
+  def build_compound_scope(scope)
+    if operator == "or"
+      combined_scope = sub_conditions
+        .map { |sub| sub.apply(scope) }
+        .reduce { |acc, s| acc.or(s) }
 
-        combined_scope || scope
-      else
-        sub_conditions.reduce(scope) { |s, sub| sub.apply(s) }
-      end
+      combined_scope || scope
+    else
+      sub_conditions.reduce(scope) { |s, sub| sub.apply(s) }
     end
+  end
 end

--- a/app/models/rule/condition_filter.rb
+++ b/app/models/rule/condition_filter.rb
@@ -60,28 +60,28 @@ class Rule::ConditionFilter
   end
 
   private
-    attr_reader :rule
+  attr_reader :rule
 
-    def family
-      rule.family
+  def family
+    rule.family
+  end
+
+  def build_sanitized_where_condition(field, operator, value)
+    sanitized_value = operator == "like" ? "%#{ActiveRecord::Base.sanitize_sql_like(value)}%" : value
+
+    ActiveRecord::Base.sanitize_sql_for_conditions([
+      "#{field} #{sanitize_operator(operator)} ?",
+      sanitized_value
+    ])
+  end
+
+  def sanitize_operator(operator)
+    raise UnsupportedOperatorError, "Unsupported operator: #{operator} for type: #{type}" unless operators.map(&:last).include?(operator)
+
+    if operator == "like"
+      "ILIKE"
+    else
+      operator
     end
-
-    def build_sanitized_where_condition(field, operator, value)
-      sanitized_value = operator == "like" ? "%#{ActiveRecord::Base.sanitize_sql_like(value)}%" : value
-
-      ActiveRecord::Base.sanitize_sql_for_conditions([
-        "#{field} #{sanitize_operator(operator)} ?",
-        sanitized_value
-      ])
-    end
-
-    def sanitize_operator(operator)
-      raise UnsupportedOperatorError, "Unsupported operator: #{operator} for type: #{type}" unless operators.map(&:last).include?(operator)
-
-      if operator == "like"
-        "ILIKE"
-      else
-        operator
-      end
-    end
+  end
 end

--- a/app/models/rule/registry.rb
+++ b/app/models/rule/registry.rb
@@ -38,9 +38,9 @@ class Rule::Registry
   end
 
   private
-    attr_reader :rule
+  attr_reader :rule
 
-    def family
-      rule.family
-    end
+  def family
+    rule.family
+  end
 end

--- a/app/models/rule/registry/transaction_resource.rb
+++ b/app/models/rule/registry/transaction_resource.rb
@@ -28,7 +28,7 @@ class Rule::Registry::TransactionResource < Rule::Registry
   end
 
   private
-    def ai_enabled?
-      Provider::Registry.get_provider(:openai).present?
-    end
+  def ai_enabled?
+    Provider::Registry.get_provider(:openai).present?
+  end
 end

--- a/app/models/security.rb
+++ b/app/models/security.rb
@@ -33,8 +33,8 @@ class Security < ApplicationRecord
   end
 
   private
-    def upcase_symbols
-      self.ticker = ticker.upcase
-      self.exchange_operating_mic = exchange_operating_mic.upcase if exchange_operating_mic.present?
-    end
+  def upcase_symbols
+    self.ticker = ticker.upcase
+    self.exchange_operating_mic = exchange_operating_mic.upcase if exchange_operating_mic.present?
+  end
 end

--- a/app/models/security/provided.rb
+++ b/app/models/security/provided.rb
@@ -106,7 +106,7 @@ module Security::Provided
   end
 
   private
-    def provider
-      self.class.provider
-    end
+  def provider
+    self.class.provider
+  end
 end

--- a/app/models/security/resolver.rb
+++ b/app/models/security/resolver.rb
@@ -20,137 +20,137 @@ class Security::Resolver
   end
 
   private
-    attr_reader :symbol, :exchange_operating_mic, :country_code
+  attr_reader :symbol, :exchange_operating_mic, :country_code
 
-    def validate_symbol!(symbol)
-      raise ArgumentError, "Symbol is required and cannot be blank" if symbol.blank?
-      symbol.strip.upcase
-    end
+  def validate_symbol!(symbol)
+    raise ArgumentError, "Symbol is required and cannot be blank" if symbol.blank?
+    symbol.strip.upcase
+  end
 
-    def offline_security
-      security = Security.find_or_initialize_by(
+  def offline_security
+    security = Security.find_or_initialize_by(
+      ticker: symbol,
+      exchange_operating_mic: exchange_operating_mic,
+    )
+
+    security.assign_attributes(
+      country_code: country_code,
+      offline: true # This tells us that we shouldn't try to fetch prices later
+    )
+
+    security.save!
+
+    security
+  end
+
+  def exact_match_from_db
+    Security.find_by(
+      {
         ticker: symbol,
         exchange_operating_mic: exchange_operating_mic,
-      )
+        country_code: country_code.presence
+      }.compact
+    )
+  end
 
-      security.assign_attributes(
-        country_code: country_code,
-        offline: true # This tells us that we shouldn't try to fetch prices later
-      )
+  # If provided a ticker + exchange (and optionally, a country code), we can find exact matches
+  def exact_match_from_provider
+    # Without an exchange, we can never know if we have an exact match
+    return nil unless exchange_operating_mic.present?
 
-      security.save!
+    match = provider_search_result.find do |s|
+      ticker_matches = s.ticker.upcase.to_s == symbol.upcase.to_s
+      exchange_matches = s.exchange_operating_mic.upcase.to_s == exchange_operating_mic.upcase.to_s
 
-      security
-    end
-
-    def exact_match_from_db
-      Security.find_by(
-        {
-          ticker: symbol,
-          exchange_operating_mic: exchange_operating_mic,
-          country_code: country_code.presence
-        }.compact
-      )
-    end
-
-    # If provided a ticker + exchange (and optionally, a country code), we can find exact matches
-    def exact_match_from_provider
-      # Without an exchange, we can never know if we have an exact match
-      return nil unless exchange_operating_mic.present?
-
-      match = provider_search_result.find do |s|
-        ticker_matches = s.ticker.upcase.to_s == symbol.upcase.to_s
-        exchange_matches = s.exchange_operating_mic.upcase.to_s == exchange_operating_mic.upcase.to_s
-
-        if country_code && exchange_operating_mic
-          ticker_matches && exchange_matches && s.country_code.upcase.to_s == country_code.upcase.to_s
-        else
-          ticker_matches && exchange_matches
-        end
+      if country_code && exchange_operating_mic
+        ticker_matches && exchange_matches && s.country_code.upcase.to_s == country_code.upcase.to_s
+      else
+        ticker_matches && exchange_matches
       end
-
-      return nil unless match
-
-      find_or_create_provider_match!(match)
     end
 
-    def close_match_from_provider
-      filtered_candidates = provider_search_result
+    return nil unless match
 
-      # If a country code is specified, we MUST find a match with the same code
-      if country_code.present?
-        filtered_candidates = filtered_candidates.select { |s| s.country_code.upcase.to_s == country_code.upcase.to_s }
-      end
+    find_or_create_provider_match!(match)
+  end
 
-      # 1. Prefer exact exchange_operating_mic matches (if one was provided)
-      # 2. Rank by country relevance (lower index in the list is more relevant)
-      # 3. Rank by exchange_operating_mic relevance (lower index in the list is more relevant)
-      sorted_candidates = filtered_candidates.sort_by do |s|
-        [
-          exchange_operating_mic.present? && s.exchange_operating_mic.upcase.to_s == exchange_operating_mic.upcase.to_s ? 0 : 1,
-          sorted_country_codes_by_relevance.index(s.country_code&.upcase.to_s) || sorted_country_codes_by_relevance.length,
-          sorted_exchange_operating_mics_by_relevance.index(s.exchange_operating_mic&.upcase.to_s) || sorted_exchange_operating_mics_by_relevance.length
-        ]
-      end
+  def close_match_from_provider
+    filtered_candidates = provider_search_result
 
-      match = sorted_candidates.first
-
-      return nil unless match
-
-      find_or_create_provider_match!(match)
+    # If a country code is specified, we MUST find a match with the same code
+    if country_code.present?
+      filtered_candidates = filtered_candidates.select { |s| s.country_code.upcase.to_s == country_code.upcase.to_s }
     end
 
-    def find_or_create_provider_match!(match)
-      security = Security.find_or_initialize_by(
-        ticker: match.ticker,
-        exchange_operating_mic: match.exchange_operating_mic,
-      )
-
-      security.country_code = match.country_code
-      security.save!
-
-      security
-    end
-
-    def provider_search_result
-      params = {
-        exchange_operating_mic: exchange_operating_mic,
-        country_code: country_code
-      }.compact_blank
-
-      @provider_search_result ||= Security.search_provider(symbol, **params)
-    end
-
-    # Non-exhaustive list of common country codes for help in choosing "close" matches
-    # These are generally sorted by market cap.
-    def sorted_country_codes_by_relevance
-      %w[US CN JP IN GB CA FR DE CH SA TW AU NL SE KR IE ES AE IT HK BR DK SG MX RU IL ID BE TH NO]
-    end
-
-    # Non-exhaustive list of common exchange operating MICs for help in choosing "close" matches
-    # This is very US-centric since our prices provider and user base is a majority US-based
-    def sorted_exchange_operating_mics_by_relevance
+    # 1. Prefer exact exchange_operating_mic matches (if one was provided)
+    # 2. Rank by country relevance (lower index in the list is more relevant)
+    # 3. Rank by exchange_operating_mic relevance (lower index in the list is more relevant)
+    sorted_candidates = filtered_candidates.sort_by do |s|
       [
-        "XNYS",  # New York Stock Exchange
-        "XNAS",  # NASDAQ Stock Market
-        "XOTC",  # OTC Markets Group (OTC Link)
-        "OTCM",  # OTC Markets Group
-        "OTCN",  # OTC Bulletin Board
-        "OTCI",  # OTC International
-        "OPRA",  # Options Price Reporting Authority
-        "MEMX",  # Members Exchange
-        "IEXA",  # IEX All-Market
-        "IEXG",  # IEX Growth Market
-        "EDXM",  # Cboe EDGX Exchange (Equities)
-        "XCME",  # CME Group (Derivatives)
-        "XCBT",  # Chicago Board of Trade
-        "XPUS",  # Nasdaq PSX (U.S.)
-        "XPSE",  # Nasdaq PHLX (U.S.)
-        "XTRD",  # Nasdaq TRF (Trade Reporting Facility)
-        "XTXD",  # FINRA TRACE (Trade Reporting)
-        "XARC",  # NYSE Arca
-        "XBOX",  # BOX Options Exchange
-        "XBXO"  # BZX Options (Cboe)
+        exchange_operating_mic.present? && s.exchange_operating_mic.upcase.to_s == exchange_operating_mic.upcase.to_s ? 0 : 1,
+        sorted_country_codes_by_relevance.index(s.country_code&.upcase.to_s) || sorted_country_codes_by_relevance.length,
+        sorted_exchange_operating_mics_by_relevance.index(s.exchange_operating_mic&.upcase.to_s) || sorted_exchange_operating_mics_by_relevance.length
       ]
     end
+
+    match = sorted_candidates.first
+
+    return nil unless match
+
+    find_or_create_provider_match!(match)
+  end
+
+  def find_or_create_provider_match!(match)
+    security = Security.find_or_initialize_by(
+      ticker: match.ticker,
+      exchange_operating_mic: match.exchange_operating_mic,
+    )
+
+    security.country_code = match.country_code
+    security.save!
+
+    security
+  end
+
+  def provider_search_result
+    params = {
+      exchange_operating_mic: exchange_operating_mic,
+      country_code: country_code
+    }.compact_blank
+
+    @provider_search_result ||= Security.search_provider(symbol, **params)
+  end
+
+  # Non-exhaustive list of common country codes for help in choosing "close" matches
+  # These are generally sorted by market cap.
+  def sorted_country_codes_by_relevance
+    %w[US CN JP IN GB CA FR DE CH SA TW AU NL SE KR IE ES AE IT HK BR DK SG MX RU IL ID BE TH NO]
+  end
+
+  # Non-exhaustive list of common exchange operating MICs for help in choosing "close" matches
+  # This is very US-centric since our prices provider and user base is a majority US-based
+  def sorted_exchange_operating_mics_by_relevance
+    [
+      "XNYS",  # New York Stock Exchange
+      "XNAS",  # NASDAQ Stock Market
+      "XOTC",  # OTC Markets Group (OTC Link)
+      "OTCM",  # OTC Markets Group
+      "OTCN",  # OTC Bulletin Board
+      "OTCI",  # OTC International
+      "OPRA",  # Options Price Reporting Authority
+      "MEMX",  # Members Exchange
+      "IEXA",  # IEX All-Market
+      "IEXG",  # IEX Growth Market
+      "EDXM",  # Cboe EDGX Exchange (Equities)
+      "XCME",  # CME Group (Derivatives)
+      "XCBT",  # Chicago Board of Trade
+      "XPUS",  # Nasdaq PSX (U.S.)
+      "XPSE",  # Nasdaq PHLX (U.S.)
+      "XTRD",  # Nasdaq TRF (Trade Reporting Facility)
+      "XTXD",  # FINRA TRACE (Trade Reporting)
+      "XARC",  # NYSE Arca
+      "XBOX",  # BOX Options Exchange
+      "XBXO"  # BZX Options (Cboe)
+    ]
+  end
 end

--- a/app/models/trade/create_form.rb
+++ b/app/models/trade/create_form.rb
@@ -18,94 +18,94 @@ class Trade::CreateForm
   end
 
   private
-    # Users can either look up a ticker from our provider (Synth) or enter a manual, "offline" ticker (that we won't fetch prices for)
-    def security
-      ticker_symbol, exchange_operating_mic = ticker.present? ? ticker.split("|") : [manual_ticker, nil]
+  # Users can either look up a ticker from our provider (Synth) or enter a manual, "offline" ticker (that we won't fetch prices for)
+  def security
+    ticker_symbol, exchange_operating_mic = ticker.present? ? ticker.split("|") : [manual_ticker, nil]
 
-      Security::Resolver.new(
-        ticker_symbol,
-        exchange_operating_mic: exchange_operating_mic
-      ).resolve
-    end
+    Security::Resolver.new(
+      ticker_symbol,
+      exchange_operating_mic: exchange_operating_mic
+    ).resolve
+  end
 
-    def create_trade
-      signed_qty = type == "sell" ? -qty.to_d : qty.to_d
-      signed_amount = signed_qty * price.to_d
+  def create_trade
+    signed_qty = type == "sell" ? -qty.to_d : qty.to_d
+    signed_amount = signed_qty * price.to_d
 
-      trade_entry = account.entries.new(
-        name: Trade.build_name(type, qty, security.ticker),
-        date: date,
-        amount: signed_amount,
+    trade_entry = account.entries.new(
+      name: Trade.build_name(type, qty, security.ticker),
+      date: date,
+      amount: signed_amount,
+      currency: currency,
+      entryable: Trade.new(
+        qty: signed_qty,
+        price: price,
         currency: currency,
-        entryable: Trade.new(
-          qty: signed_qty,
-          price: price,
-          currency: currency,
-          security: security
-        )
+        security: security
       )
+    )
 
-      if trade_entry.save
-        trade_entry.lock_saved_attributes!
-        account.sync_later
-      end
-
-      trade_entry
+    if trade_entry.save
+      trade_entry.lock_saved_attributes!
+      account.sync_later
     end
 
-    def create_interest_income
-      signed_amount = amount.to_d * -1
+    trade_entry
+  end
 
-      entry = account.entries.build(
-        name: "Interest payment",
+  def create_interest_income
+    signed_amount = amount.to_d * -1
+
+    entry = account.entries.build(
+      name: "Interest payment",
+      date: date,
+      amount: signed_amount,
+      currency: currency,
+      entryable: Transaction.new
+    )
+
+    if entry.save
+      entry.lock_saved_attributes!
+      account.sync_later
+    end
+
+    entry
+  end
+
+  def create_transfer
+    if transfer_account_id.present?
+      from_account_id = type == "withdrawal" ? account.id : transfer_account_id
+      to_account_id = type == "withdrawal" ? transfer_account_id : account.id
+
+      Transfer::Creator.new(
+        family: account.family,
+        source_account_id: from_account_id,
+        destination_account_id: to_account_id,
         date: date,
-        amount: signed_amount,
-        currency: currency,
-        entryable: Transaction.new
-      )
+        amount: amount
+      ).create
+    else
+      create_unlinked_transfer
+    end
+  end
 
-      if entry.save
-        entry.lock_saved_attributes!
-        account.sync_later
-      end
+  # If user doesn't provide the reciprocal account, it's a regular transaction
+  def create_unlinked_transfer
+    signed_amount = type == "deposit" ? amount.to_d * -1 : amount.to_d
 
-      entry
+    entry = account.entries.build(
+      name: signed_amount < 0 ? "Deposit to #{account.name}" : "Withdrawal from #{account.name}",
+      date: date,
+      amount: signed_amount,
+      currency: currency,
+      entryable: Transaction.new
+    )
+
+    if entry.save
+      entry.lock_saved_attributes!
+      account.sync_later
     end
 
-    def create_transfer
-      if transfer_account_id.present?
-        from_account_id = type == "withdrawal" ? account.id : transfer_account_id
-        to_account_id = type == "withdrawal" ? transfer_account_id : account.id
-
-        Transfer::Creator.new(
-          family: account.family,
-          source_account_id: from_account_id,
-          destination_account_id: to_account_id,
-          date: date,
-          amount: amount
-        ).create
-      else
-        create_unlinked_transfer
-      end
-    end
-
-    # If user doesn't provide the reciprocal account, it's a regular transaction
-    def create_unlinked_transfer
-      signed_amount = type == "deposit" ? amount.to_d * -1 : amount.to_d
-
-      entry = account.entries.build(
-        name: signed_amount < 0 ? "Deposit to #{account.name}" : "Withdrawal from #{account.name}",
-        date: date,
-        amount: signed_amount,
-        currency: currency,
-        entryable: Transaction.new
-      )
-
-      if entry.save
-        entry.lock_saved_attributes!
-        account.sync_later
-      end
-
-      entry
-    end
+    entry
+  end
 end

--- a/app/models/trade_import.rb
+++ b/app/models/trade_import.rb
@@ -76,25 +76,25 @@ class TradeImport < Import
   end
 
   private
-    def find_or_create_security(ticker: nil, exchange_operating_mic: nil)
-      return nil unless ticker.present?
+  def find_or_create_security(ticker: nil, exchange_operating_mic: nil)
+    return nil unless ticker.present?
 
-      # Avoids resolving the same security over and over again (resolver potentially makes network calls)
-      @security_cache ||= {}
+    # Avoids resolving the same security over and over again (resolver potentially makes network calls)
+    @security_cache ||= {}
 
-      cache_key = [ticker, exchange_operating_mic].compact.join(":")
+    cache_key = [ticker, exchange_operating_mic].compact.join(":")
 
-      security = @security_cache[cache_key]
+    security = @security_cache[cache_key]
 
-      return security if security.present?
+    return security if security.present?
 
-      security = Security::Resolver.new(
-        ticker,
-        exchange_operating_mic: exchange_operating_mic.presence
-      ).resolve
+    security = Security::Resolver.new(
+      ticker,
+      exchange_operating_mic: exchange_operating_mic.presence
+    ).resolve
 
-      @security_cache[cache_key] = security
+    @security_cache[cache_key] = security
 
-      security
-    end
+    security
+  end
 end

--- a/app/models/transaction/ruleable.rb
+++ b/app/models/transaction/ruleable.rb
@@ -11,7 +11,7 @@ module Transaction::Ruleable
   end
 
   private
-    def rules
-      entry.account.family.rules
-    end
+  def rules
+    entry.account.family.rules
+  end
 end

--- a/app/models/transaction/search.rb
+++ b/app/models/transaction/search.rb
@@ -77,67 +77,67 @@ class Transaction::Search
   end
 
   private
-    Totals = Data.define(:count, :income_money, :expense_money)
+  Totals = Data.define(:count, :income_money, :expense_money)
 
-    def apply_active_accounts_filter(query, active_accounts_only_filter)
-      if active_accounts_only_filter
-        query.where(accounts: { status: ["draft", "active"] })
-      else
-        query
-      end
-    end
-
-
-    def apply_category_filter(query, categories)
-      return query unless categories.present?
-
-      query = query.left_joins(:category).where(
-        "categories.name IN (?) OR (
-        categories.id IS NULL AND (transactions.kind NOT IN ('funds_movement', 'cc_payment'))
-      )",
-        categories
-      )
-
-      if categories.exclude?("Uncategorized")
-        query = query.where.not(category_id: nil)
-      end
-
+  def apply_active_accounts_filter(query, active_accounts_only_filter)
+    if active_accounts_only_filter
+      query.where(accounts: { status: ["draft", "active"] })
+    else
       query
     end
+  end
 
-    def apply_type_filter(query, types)
-      return query unless types.present?
-      return query if types.sort == ["expense", "income", "transfer"]
 
-      transfer_condition = "transactions.kind IN ('funds_movement', 'cc_payment', 'loan_payment')"
-      expense_condition = "entries.amount >= 0"
-      income_condition = "entries.amount <= 0"
+  def apply_category_filter(query, categories)
+    return query unless categories.present?
 
-      condition = case types.sort
-      when ["transfer"]
-        transfer_condition
-      when ["expense"]
-        Arel.sql("#{expense_condition} AND NOT (#{transfer_condition})")
-      when ["income"]
-        Arel.sql("#{income_condition} AND NOT (#{transfer_condition})")
-      when ["expense", "transfer"]
-        Arel.sql("#{expense_condition} OR #{transfer_condition}")
-      when ["income", "transfer"]
-        Arel.sql("#{income_condition} OR #{transfer_condition}")
-      when ["expense", "income"]
-        Arel.sql("NOT (#{transfer_condition})")
-      end
+    query = query.left_joins(:category).where(
+      "categories.name IN (?) OR (
+        categories.id IS NULL AND (transactions.kind NOT IN ('funds_movement', 'cc_payment'))
+      )",
+      categories
+    )
 
-      query.where(condition)
+    if categories.exclude?("Uncategorized")
+      query = query.where.not(category_id: nil)
     end
 
-    def apply_merchant_filter(query, merchants)
-      return query unless merchants.present?
-      query.joins(:merchant).where(merchants: { name: merchants })
+    query
+  end
+
+  def apply_type_filter(query, types)
+    return query unless types.present?
+    return query if types.sort == ["expense", "income", "transfer"]
+
+    transfer_condition = "transactions.kind IN ('funds_movement', 'cc_payment', 'loan_payment')"
+    expense_condition = "entries.amount >= 0"
+    income_condition = "entries.amount <= 0"
+
+    condition = case types.sort
+    when ["transfer"]
+      transfer_condition
+    when ["expense"]
+      Arel.sql("#{expense_condition} AND NOT (#{transfer_condition})")
+    when ["income"]
+      Arel.sql("#{income_condition} AND NOT (#{transfer_condition})")
+    when ["expense", "transfer"]
+      Arel.sql("#{expense_condition} OR #{transfer_condition}")
+    when ["income", "transfer"]
+      Arel.sql("#{income_condition} OR #{transfer_condition}")
+    when ["expense", "income"]
+      Arel.sql("NOT (#{transfer_condition})")
     end
 
-    def apply_tag_filter(query, tags)
-      return query unless tags.present?
-      query.joins(:tags).where(tags: { name: tags })
-    end
+    query.where(condition)
+  end
+
+  def apply_merchant_filter(query, merchants)
+    return query unless merchants.present?
+    query.joins(:merchant).where(merchants: { name: merchants })
+  end
+
+  def apply_tag_filter(query, tags)
+    return query unless tags.present?
+    query.joins(:tags).where(tags: { name: tags })
+  end
 end

--- a/app/models/transaction/transferable.rb
+++ b/app/models/transaction/transferable.rb
@@ -30,7 +30,7 @@ module Transaction::Transferable
   end
 
   private
-    def family_matches_scope
-      self.entry.account.family.transfer_match_candidates
-    end
+  def family_matches_scope
+    self.entry.account.family.transfer_match_candidates
+  end
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -101,38 +101,38 @@ class Transfer < ApplicationRecord
   end
 
   private
-    def transfer_has_different_accounts
-      return unless inflow_transaction&.entry && outflow_transaction&.entry
-      errors.add(:base, "Must be from different accounts") if to_account == from_account
+  def transfer_has_different_accounts
+    return unless inflow_transaction&.entry && outflow_transaction&.entry
+    errors.add(:base, "Must be from different accounts") if to_account == from_account
+  end
+
+  def transfer_has_same_family
+    return unless inflow_transaction&.entry && outflow_transaction&.entry
+    errors.add(:base, "Must be from same family") unless to_account&.family == from_account&.family
+  end
+
+  def transfer_has_opposite_amounts
+    return unless inflow_transaction&.entry && outflow_transaction&.entry
+
+    inflow_entry = inflow_transaction.entry
+    outflow_entry = outflow_transaction.entry
+
+    inflow_amount = inflow_entry.amount
+    outflow_amount = outflow_entry.amount
+
+    if inflow_entry.currency == outflow_entry.currency
+      # For same currency, amounts must be exactly opposite
+      errors.add(:base, "Must have opposite amounts") if inflow_amount + outflow_amount != 0
+    else
+      # For different currencies, just check the signs are opposite
+      errors.add(:base, "Must have opposite amounts") unless inflow_amount.negative? && outflow_amount.positive?
     end
+  end
 
-    def transfer_has_same_family
-      return unless inflow_transaction&.entry && outflow_transaction&.entry
-      errors.add(:base, "Must be from same family") unless to_account&.family == from_account&.family
-    end
+  def transfer_within_date_range
+    return unless inflow_transaction&.entry && outflow_transaction&.entry
 
-    def transfer_has_opposite_amounts
-      return unless inflow_transaction&.entry && outflow_transaction&.entry
-
-      inflow_entry = inflow_transaction.entry
-      outflow_entry = outflow_transaction.entry
-
-      inflow_amount = inflow_entry.amount
-      outflow_amount = outflow_entry.amount
-
-      if inflow_entry.currency == outflow_entry.currency
-        # For same currency, amounts must be exactly opposite
-        errors.add(:base, "Must have opposite amounts") if inflow_amount + outflow_amount != 0
-      else
-        # For different currencies, just check the signs are opposite
-        errors.add(:base, "Must have opposite amounts") unless inflow_amount.negative? && outflow_amount.positive?
-      end
-    end
-
-    def transfer_within_date_range
-      return unless inflow_transaction&.entry && outflow_transaction&.entry
-
-      date_diff = (inflow_transaction.entry.date - outflow_transaction.entry.date).abs
-      errors.add(:base, "Must be within 4 days") if date_diff > 4
-    end
+    date_diff = (inflow_transaction.entry.date - outflow_transaction.entry.date).abs
+    errors.add(:base, "Must be within 4 days") if date_diff > 4
+  end
 end

--- a/app/models/transfer/creator.rb
+++ b/app/models/transfer/creator.rb
@@ -23,63 +23,63 @@ class Transfer::Creator
   end
 
   private
-    attr_reader :family, :source_account, :destination_account, :date, :amount
+  attr_reader :family, :source_account, :destination_account, :date, :amount
 
-    def outflow_transaction
-      name = "#{name_prefix} to #{destination_account.name}"
+  def outflow_transaction
+    name = "#{name_prefix} to #{destination_account.name}"
 
-      Transaction.new(
-        kind: outflow_transaction_kind,
-        entry: source_account.entries.build(
-          amount: amount.abs,
-          currency: source_account.currency,
-          date: date,
-          name: name,
-        )
+    Transaction.new(
+      kind: outflow_transaction_kind,
+      entry: source_account.entries.build(
+        amount: amount.abs,
+        currency: source_account.currency,
+        date: date,
+        name: name,
       )
-    end
+    )
+  end
 
-    def inflow_transaction
-      name = "#{name_prefix} from #{source_account.name}"
+  def inflow_transaction
+    name = "#{name_prefix} from #{source_account.name}"
 
-      Transaction.new(
-        kind: "funds_movement",
-        entry: destination_account.entries.build(
-          amount: inflow_converted_money.amount.abs * -1,
-          currency: destination_account.currency,
-          date: date,
-          name: name,
-        )
+    Transaction.new(
+      kind: "funds_movement",
+      entry: destination_account.entries.build(
+        amount: inflow_converted_money.amount.abs * -1,
+        currency: destination_account.currency,
+        date: date,
+        name: name,
       )
-    end
+    )
+  end
 
-    # If destination account has different currency, its transaction should show up as converted
-    # Future improvement: instead of a 1:1 conversion fallback, add a UI/UX flow for missing rates
-    def inflow_converted_money
-      Money.new(amount.abs, source_account.currency)
-           .exchange_to(
-             destination_account.currency,
-             date: date,
-             fallback_rate: 1.0
-           )
-    end
+  # If destination account has different currency, its transaction should show up as converted
+  # Future improvement: instead of a 1:1 conversion fallback, add a UI/UX flow for missing rates
+  def inflow_converted_money
+    Money.new(amount.abs, source_account.currency)
+         .exchange_to(
+           destination_account.currency,
+           date: date,
+           fallback_rate: 1.0
+         )
+  end
 
-    # The "expense" side of a transfer is treated different in analytics based on where it goes.
-    def outflow_transaction_kind
-      if destination_account.loan?
-        "loan_payment"
-      elsif destination_account.liability?
-        "cc_payment"
-      else
-        "funds_movement"
-      end
+  # The "expense" side of a transfer is treated different in analytics based on where it goes.
+  def outflow_transaction_kind
+    if destination_account.loan?
+      "loan_payment"
+    elsif destination_account.liability?
+      "cc_payment"
+    else
+      "funds_movement"
     end
+  end
 
-    def name_prefix
-      if destination_account.liability?
-        "Payment"
-      else
-        "Transfer"
-      end
+  def name_prefix
+    if destination_account.liability?
+      "Payment"
+    else
+      "Transfer"
     end
+  end
 end

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -80,15 +80,15 @@ class Trend
   end
 
   private
-    def red_hex
-      "var(--color-destructive)"
-    end
+  def red_hex
+    "var(--color-destructive)"
+  end
 
-    def green_hex
-      "var(--color-success)"
-    end
+  def green_hex
+    "var(--color-success)"
+  end
 
-    def gray_hex
-      "var(--color-gray)"
-    end
+  def gray_hex
+    "var(--color-gray)"
+  end
 end

--- a/app/models/valuation/name.rb
+++ b/app/models/valuation/name.rb
@@ -16,42 +16,42 @@ class Valuation::Name
   end
 
   private
-    attr_reader :valuation_kind, :accountable_type
+  attr_reader :valuation_kind, :accountable_type
 
-    def opening_anchor_name
-      case accountable_type
-      when "Property", "Vehicle"
-        "Original purchase price"
-      when "Loan"
-        "Original principal"
-      when "Investment", "Crypto", "OtherAsset"
-        "Opening account value"
-      else
-        "Opening balance"
-      end
+  def opening_anchor_name
+    case accountable_type
+    when "Property", "Vehicle"
+      "Original purchase price"
+    when "Loan"
+      "Original principal"
+    when "Investment", "Crypto", "OtherAsset"
+      "Opening account value"
+    else
+      "Opening balance"
     end
+  end
 
-    def current_anchor_name
-      case accountable_type
-      when "Property", "Vehicle"
-        "Current market value"
-      when "Loan"
-        "Current loan balance"
-      when "Investment", "Crypto", "OtherAsset"
-        "Current account value"
-      else
-        "Current balance"
-      end
+  def current_anchor_name
+    case accountable_type
+    when "Property", "Vehicle"
+      "Current market value"
+    when "Loan"
+      "Current loan balance"
+    when "Investment", "Crypto", "OtherAsset"
+      "Current account value"
+    else
+      "Current balance"
     end
+  end
 
-    def recon_name
-      case accountable_type
-      when "Property", "Investment", "Vehicle", "Crypto", "OtherAsset"
-        "Manual value update"
-      when "Loan"
-        "Manual principal update"
-      else
-        "Manual balance update"
-      end
+  def recon_name
+    case accountable_type
+    when "Property", "Investment", "Vehicle", "Crypto", "OtherAsset"
+      "Manual value update"
+    when "Loan"
+      "Manual principal update"
+    else
+      "Manual balance update"
     end
+  end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -30,7 +30,7 @@ class Vehicle < ApplicationRecord
   end
 
   private
-    def first_valuation_amount
-      account.entries.valuations.order(:date).first&.amount_money || account.balance_money
-    end
+  def first_valuation_amount
+    account.entries.valuations.order(:date).first&.amount_money || account.balance_money
+  end
 end

--- a/app/services/api_rate_limiter.rb
+++ b/app/services/api_rate_limiter.rb
@@ -88,14 +88,14 @@ class ApiRateLimiter
 
   private
 
-    def current_window_start
-      (Time.current.to_i / 3600) * 3600
-    end
+  def current_window_start
+    (Time.current.to_i / 3600) * 3600
+  end
 
-    def determine_tier
-      # For now, all API keys are standard tier
-      # This can be extended later to support different tiers based on user subscription
-      # or API key configuration
-      DEFAULT_TIER
-    end
+  def determine_tier
+    # For now, all API keys are standard tier
+    # This can be extended later to support different tiers based on user subscription
+    # or API key configuration
+    DEFAULT_TIER
+  end
 end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -13,8 +13,8 @@ module Maybe
     end
 
     private
-      def semver
-        "0.6.0"
-      end
+    def semver
+      "0.6.0"
+    end
   end
 end

--- a/db/migrate/20240426162500_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240426162500_create_active_storage_tables.active_storage.rb
@@ -47,11 +47,11 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
-    end
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end

--- a/db/migrate/20240619125949_rename_accountable_tables.rb
+++ b/db/migrate/20240619125949_rename_accountable_tables.rb
@@ -77,11 +77,11 @@ class RenameAccountableTables < ActiveRecord::Migration[7.2]
 
   private
 
-    def update_accountable_types(mapping)
-      Account.reset_column_information
+  def update_accountable_types(mapping)
+    Account.reset_column_information
 
-      mapping.each do |old_type, new_type|
-        Account.where(accountable_type: old_type).update_all(accountable_type: new_type)
-      end
+    mapping.each do |old_type, new_type|
+      Account.where(accountable_type: old_type).update_all(accountable_type: new_type)
     end
+  end
 end

--- a/db/migrate/20251213223125_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20251213223125_create_active_storage_variant_records.active_storage.rb
@@ -14,14 +14,14 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   end
 
   private
-    def primary_key_type
-      config = Rails.configuration.generators
-      config.options[config.orm][:primary_key_type] || :primary_key
-    end
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
+  end
 
-    def blobs_primary_key_type
-      pkey_name = connection.primary_key(:active_storage_blobs)
-      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
-      pkey_column.bigint? ? :bigint : pkey_column.type
-    end
+  def blobs_primary_key_type
+    pkey_name = connection.primary_key(:active_storage_blobs)
+    pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+    pkey_column.bigint? ? :bigint : pkey_column.type
+  end
 end

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -75,9 +75,9 @@ class Money
   end
 
   private
-    def source_must_be_of_known_type
-      unless @source.is_a?(Money) || @source.is_a?(Numeric) || @source.is_a?(BigDecimal)
-        errors.add :source, "must be a Money, Numeric, or BigDecimal"
-      end
+  def source_must_be_of_known_type
+    unless @source.is_a?(Money) || @source.is_a?(Numeric) || @source.is_a?(BigDecimal)
+      errors.add :source, "must be a Money, Numeric, or BigDecimal"
     end
+  end
 end

--- a/lib/money/formatting.rb
+++ b/lib/money/formatting.rb
@@ -22,22 +22,22 @@ module Money::Formatting
   end
 
   private
-    def get_symbol
-      if currency.symbol == "$" && currency.iso_code != "USD"
-        [currency.iso_code.first(2), currency.symbol].join
-      else
-        currency.symbol
-      end
+  def get_symbol
+    if currency.symbol == "$" && currency.iso_code != "USD"
+      [currency.iso_code.first(2), currency.symbol].join
+    else
+      currency.symbol
     end
+  end
 
-    def locale_options(locale)
-      case [currency.iso_code, locale.to_sym]
-      when ["EUR", :nl], ["EUR", :pt]
-        { delimiter: ".", separator: ",", format: "%u %n" }
-      when ["EUR", :en], ["EUR", :en_IE]
-        { delimiter: ",", separator: "." }
-      else
-        {}
-      end
+  def locale_options(locale)
+    case [currency.iso_code, locale.to_sym]
+    when ["EUR", :nl], ["EUR", :pt]
+      { delimiter: ".", separator: ",", format: "%u %n" }
+    when ["EUR", :en], ["EUR", :en_IE]
+      { delimiter: ",", separator: "." }
+    else
+      {}
     end
+  end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -17,33 +17,33 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   private
 
-    def sign_in(user)
-      visit new_session_path
-      within "form" do
-        fill_in "Email", with: user.email
-        fill_in "Password", with: user_password_test
-        click_on "Log in"
-      end
-
-      # Trigger Capybara's wait mechanism to avoid timing issues with logins
-      find("h1", text: "Welcome back, #{user.first_name}")
+  def sign_in(user)
+    visit new_session_path
+    within "form" do
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user_password_test
+      click_on "Log in"
     end
 
-    def login_as(user)
-      sign_in(user)
-    end
+    # Trigger Capybara's wait mechanism to avoid timing issues with logins
+    find("h1", text: "Welcome back, #{user.first_name}")
+  end
 
-    def sign_out
-      find("#user-menu").click
-      click_button "Logout"
+  def login_as(user)
+    sign_in(user)
+  end
 
-      # Trigger Capybara's wait mechanism to avoid timing issues with logout
-      find("h2", text: "Sign in to your account")
-    end
+  def sign_out
+    find("#user-menu").click
+    click_button "Logout"
 
-    def within_testid(testid)
-      within "[data-testid='#{testid}']" do
-        yield
-      end
+    # Trigger Capybara's wait mechanism to avoid timing issues with logout
+    find("h2", text: "Sign in to your account")
+  end
+
+  def within_testid(testid)
+    within "[data-testid='#{testid}']" do
+      yield
     end
+  end
 end

--- a/test/components/previews/menu_component_preview.rb
+++ b/test/components/previews/menu_component_preview.rb
@@ -19,26 +19,26 @@ class MenuComponentPreview < ViewComponent::Preview
   end
 
   private
-    def menu_contents(menu)
-      menu.with_header do
-        content_tag(:div, class: "p-3") do
-          content_tag(:h3, "Menu header", class: "font-medium text-gray-900")
-        end
-      end
-
-      menu.with_item(variant: "link", text: "Link", href: "#", icon: "plus")
-      menu.with_item(variant: "button", text: "Action", href: "#", method: :post, icon: "circle")
-      menu.with_item(variant: "button", text: "Action destructive", href: "#", method: :delete, icon: "circle")
-
-      menu.with_item(variant: "divider")
-
-      menu.with_custom_content do
-        content_tag(:div, class: "p-4") do
-          safe_join([
-            content_tag(:h3, "Custom content header", class: "font-medium text-gray-900"),
-            content_tag(:p, "Some custom content", class: "text-sm text-gray-500")
-          ])
-        end
+  def menu_contents(menu)
+    menu.with_header do
+      content_tag(:div, class: "p-3") do
+        content_tag(:h3, "Menu header", class: "font-medium text-gray-900")
       end
     end
+
+    menu.with_item(variant: "link", text: "Link", href: "#", icon: "plus")
+    menu.with_item(variant: "button", text: "Action", href: "#", method: :post, icon: "circle")
+    menu.with_item(variant: "button", text: "Action destructive", href: "#", method: :delete, icon: "circle")
+
+    menu.with_item(variant: "divider")
+
+    menu.with_custom_content do
+      content_tag(:div, class: "p-4") do
+        safe_join([
+          content_tag(:h3, "Custom content header", class: "font-medium text-gray-900"),
+          content_tag(:p, "Some custom content", class: "text-sm text-gray-500")
+        ])
+      end
+    end
+  end
 end

--- a/test/controllers/api/v1/chats_controller_test.rb
+++ b/test/controllers/api/v1/chats_controller_test.rb
@@ -127,7 +127,7 @@ class Api::V1::ChatsControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-    def bearer_auth_header(token)
-      { "Authorization" => "Bearer #{token.token}" }
-    end
+  def bearer_auth_header(token)
+    { "Authorization" => "Bearer #{token.token}" }
+  end
 end

--- a/test/controllers/api/v1/messages_controller_test.rb
+++ b/test/controllers/api/v1/messages_controller_test.rb
@@ -105,7 +105,7 @@ class Api::V1::MessagesControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-    def bearer_auth_header(token)
-      { "Authorization" => "Bearer #{token.token}" }
-    end
+  def bearer_auth_header(token)
+    { "Authorization" => "Bearer #{token.token}" }
+  end
 end

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -355,7 +355,7 @@ end
 
   private
 
-    def api_headers(api_key)
-      { "X-Api-Key" => api_key.display_key }
-    end
+  def api_headers(api_key)
+    { "X-Api-Key" => api_key.display_key }
+  end
 end

--- a/test/controllers/import/rows_controller_test.rb
+++ b/test/controllers/import/rows_controller_test.rb
@@ -71,9 +71,9 @@ class Import::RowsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
-    def assert_row_fields(row, fields)
-      fields.each do |field|
-        assert_select "turbo-frame##{dom_id(row, field)}"
-      end
+  def assert_row_fields(row, fields)
+    fields.each do |field|
+      assert_select "turbo-frame##{dom_id(row, field)}"
     end
+  end
 end

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -161,9 +161,9 @@ end
 
     private
 
-      def sign_out
-        @user.sessions.each do |session|
-          delete session_path(session)
-        end
-      end
+  def sign_out
+    @user.sessions.each do |session|
+      delete session_path(session)
+    end
+  end
 end

--- a/test/data_migrations/balance_component_migrator_test.rb
+++ b/test/data_migrations/balance_component_migrator_test.rb
@@ -108,53 +108,53 @@ class BalanceComponentMigratorTest < ActiveSupport::TestCase
   end
 
   private
-    def create_balance_history(account, balances)
-      balances.each do |balance|
-        account.balances.create!(
-          date: balance[:date].to_date,
-          balance: balance[:balance],
-          cash_balance: balance[:cash_balance],
-          currency: account.currency
-        )
-      end
+  def create_balance_history(account, balances)
+    balances.each do |balance|
+      account.balances.create!(
+        date: balance[:date].to_date,
+        balance: balance[:balance],
+        cash_balance: balance[:cash_balance],
+        currency: account.currency
+      )
     end
+  end
 
-    def assert_migrated_balances(account, expected)
-      balances = account.balances.order(:date)
+  def assert_migrated_balances(account, expected)
+    balances = account.balances.order(:date)
 
-      expected.each_with_index do |expected_values, index|
-        balance = balances.find { |b| b.date == expected_values[:date].to_date }
-        assert balance, "Expected balance for #{expected_values[:date].to_date} but none found"
+    expected.each_with_index do |expected_values, index|
+      balance = balances.find { |b| b.date == expected_values[:date].to_date }
+      assert balance, "Expected balance for #{expected_values[:date].to_date} but none found"
 
-        # Assert expected values
-        assert_equal expected_values[:start_cash], balance.start_cash_balance,
-          "start_cash_balance mismatch for #{balance.date}"
-        assert_equal expected_values[:start_non_cash], balance.start_non_cash_balance,
-          "start_non_cash_balance mismatch for #{balance.date}"
-        assert_equal expected_values[:start], balance.start_balance,
-          "start_balance mismatch for #{balance.date}"
-        assert_equal expected_values[:cash_inflows], balance.cash_inflows,
-          "cash_inflows mismatch for #{balance.date}"
-        assert_equal expected_values[:non_cash_inflows], balance.non_cash_inflows,
-          "non_cash_inflows mismatch for #{balance.date}"
-        assert_equal expected_values[:end_cash], balance.end_cash_balance,
-          "end_cash_balance mismatch for #{balance.date}"
-        assert_equal expected_values[:end_non_cash], balance.end_non_cash_balance,
-          "end_non_cash_balance mismatch for #{balance.date}"
-        assert_equal expected_values[:end], balance.end_balance,
-          "end_balance mismatch for #{balance.date}"
+      # Assert expected values
+      assert_equal expected_values[:start_cash], balance.start_cash_balance,
+        "start_cash_balance mismatch for #{balance.date}"
+      assert_equal expected_values[:start_non_cash], balance.start_non_cash_balance,
+        "start_non_cash_balance mismatch for #{balance.date}"
+      assert_equal expected_values[:start], balance.start_balance,
+        "start_balance mismatch for #{balance.date}"
+      assert_equal expected_values[:cash_inflows], balance.cash_inflows,
+        "cash_inflows mismatch for #{balance.date}"
+      assert_equal expected_values[:non_cash_inflows], balance.non_cash_inflows,
+        "non_cash_inflows mismatch for #{balance.date}"
+      assert_equal expected_values[:end_cash], balance.end_cash_balance,
+        "end_cash_balance mismatch for #{balance.date}"
+      assert_equal expected_values[:end_non_cash], balance.end_non_cash_balance,
+        "end_non_cash_balance mismatch for #{balance.date}"
+      assert_equal expected_values[:end], balance.end_balance,
+        "end_balance mismatch for #{balance.date}"
 
-        # Assert zeros for other fields
-        assert_equal 0, balance.cash_outflows,
-          "cash_outflows should be zero for #{balance.date}"
-        assert_equal 0, balance.non_cash_outflows,
-          "non_cash_outflows should be zero for #{balance.date}"
-        assert_equal 0, balance.cash_adjustments,
-          "cash_adjustments should be zero for #{balance.date}"
-        assert_equal 0, balance.non_cash_adjustments,
-          "non_cash_adjustments should be zero for #{balance.date}"
-        assert_equal 0, balance.net_market_flows,
-          "net_market_flows should be zero for #{balance.date}"
-      end
+      # Assert zeros for other fields
+      assert_equal 0, balance.cash_outflows,
+        "cash_outflows should be zero for #{balance.date}"
+      assert_equal 0, balance.non_cash_outflows,
+        "non_cash_outflows should be zero for #{balance.date}"
+      assert_equal 0, balance.cash_adjustments,
+        "cash_adjustments should be zero for #{balance.date}"
+      assert_equal 0, balance.non_cash_adjustments,
+        "non_cash_adjustments should be zero for #{balance.date}"
+      assert_equal 0, balance.net_market_flows,
+        "net_market_flows should be zero for #{balance.date}"
     end
+  end
 end

--- a/test/interfaces/exchange_rate_provider_interface_test.rb
+++ b/test/interfaces/exchange_rate_provider_interface_test.rb
@@ -32,7 +32,7 @@ module ExchangeRateProviderInterfaceTest
   end
 
   private
-    def vcr_key_prefix
-      @subject.class.name.demodulize.underscore
-    end
+  def vcr_key_prefix
+    @subject.class.name.demodulize.underscore
+  end
 end

--- a/test/interfaces/llm_interface_test.rb
+++ b/test/interfaces/llm_interface_test.rb
@@ -4,7 +4,7 @@ module LLMInterfaceTest
   extend ActiveSupport::Testing::Declarative
 
   private
-    def vcr_key_prefix
-      @subject.class.name.demodulize.underscore
-    end
+  def vcr_key_prefix
+    @subject.class.name.demodulize.underscore
+  end
 end

--- a/test/interfaces/security_provider_interface_test.rb
+++ b/test/interfaces/security_provider_interface_test.rb
@@ -62,7 +62,7 @@ module SecurityProviderInterfaceTest
   end
 
   private
-    def vcr_key_prefix
-      @subject.class.name.demodulize.underscore
-    end
+  def vcr_key_prefix
+    @subject.class.name.demodulize.underscore
+  end
 end

--- a/test/models/account/activity_feed_data_test.rb
+++ b/test/models/account/activity_feed_data_test.rb
@@ -187,43 +187,24 @@ class Account::ActivityFeedDataTest < ActiveSupport::TestCase
   end
 
   private
-    def find_activity_for_date(activities, date)
-      activities.find { |a| a.date == date }
-    end
+  def find_activity_for_date(activities, date)
+    activities.find { |a| a.date == date }
+  end
 
-    def setup_test_data
-      # Create daily balances for checking account with new schema
-      5.times do |i|
-        date = @test_period_start + i.days
-        prev_balance = i > 0 ? 1000 + ((i - 1) * 100) : 0
+  def setup_test_data
+    # Create daily balances for checking account with new schema
+    5.times do |i|
+      date = @test_period_start + i.days
+      prev_balance = i > 0 ? 1000 + ((i - 1) * 100) : 0
 
-        @checking.balances.create!(
-          date: date,
-          balance: 1000 + (i * 100),  # Keep old field for now
-          cash_balance: 1000 + (i * 100),  # Keep old field for now
-          start_balance: prev_balance,
-          start_cash_balance: prev_balance,
-          start_non_cash_balance: 0,
-          cash_inflows: i == 0 ? 1000 : 100,
-          cash_outflows: 0,
-          non_cash_inflows: 0,
-          non_cash_outflows: 0,
-          net_market_flows: 0,
-          cash_adjustments: 0,
-          non_cash_adjustments: 0,
-          currency: "USD"
-        )
-      end
-
-      # Create daily balances for investment account with cash_balance
-      @investment.balances.create!(
-        date: @test_period_start,
-        balance: 500,  # Keep old field for now
-        cash_balance: 500,  # Keep old field for now
-        start_balance: 0,
-        start_cash_balance: 0,
+      @checking.balances.create!(
+        date: date,
+        balance: 1000 + (i * 100),  # Keep old field for now
+        cash_balance: 1000 + (i * 100),  # Keep old field for now
+        start_balance: prev_balance,
+        start_cash_balance: prev_balance,
         start_non_cash_balance: 0,
-        cash_inflows: 500,
+        cash_inflows: i == 0 ? 1000 : 100,
         cash_outflows: 0,
         non_cash_inflows: 0,
         non_cash_outflows: 0,
@@ -232,86 +213,105 @@ class Account::ActivityFeedDataTest < ActiveSupport::TestCase
         non_cash_adjustments: 0,
         currency: "USD"
       )
-      @investment.balances.create!(
-        date: @test_period_start + 1.day,
-        balance: 500,  # Keep old field for now
-        cash_balance: 500,  # Keep old field for now
-        start_balance: 500,
-        start_cash_balance: 500,
-        start_non_cash_balance: 0,
-        cash_inflows: 0,
-        cash_outflows: 0,
-        non_cash_inflows: 0,
-        non_cash_outflows: 0,
-        net_market_flows: 0,
-        cash_adjustments: 0,
-        non_cash_adjustments: 0,
-        currency: "USD"
-      )
-      @investment.balances.create!(
-        date: @test_period_start + 2.days,
-        balance: 1900,  # Keep old field for now
-        cash_balance: 400,  # Keep old field for now
-        start_balance: 500,
-        start_cash_balance: 500,
-        start_non_cash_balance: 0,
-        cash_inflows: 0,
-        cash_outflows: 100,
-        non_cash_inflows: 1500,
-        non_cash_outflows: 0,
-        net_market_flows: 0,
-        cash_adjustments: 0,
-        non_cash_adjustments: 0,
-        currency: "USD"
-      )
-
-      # Day 1: Regular transaction
-      create_transaction(
-        account: @checking,
-        date: @test_period_start,
-        amount: -50,
-        name: "Grocery Store"
-      )
-
-      # Day 2: Transfer between accounts
-      @transfer = create_transfer(
-        from_account: @checking,
-        to_account: @savings,
-        amount: 200,
-        date: @test_period_start + 1.day
-      )
-
-      # Day 3: Trade in investment account
-      create_trade(
-        securities(:aapl),
-        account: @investment,
-        qty: 10,
-        date: @test_period_start + 2.days,
-        price: 150
-      )
-
-      # Day 3: Foreign currency transaction
-      create_transaction(
-        account: @investment,
-        date: @test_period_start + 2.days,
-        amount: -100,
-        currency: "EUR",
-        name: "International Wire"
-      )
-
-      # Create exchange rate for foreign currency
-      ExchangeRate.create!(
-        date: @test_period_start + 2.days,
-        from_currency: "EUR",
-        to_currency: "USD",
-        rate: 1.1
-      )
-
-      # Day 4: Valuation
-      create_valuation(
-        account: @investment,
-        date: @test_period_start + 3.days,
-        amount: 25
-      )
     end
+
+    # Create daily balances for investment account with cash_balance
+    @investment.balances.create!(
+      date: @test_period_start,
+      balance: 500,  # Keep old field for now
+      cash_balance: 500,  # Keep old field for now
+      start_balance: 0,
+      start_cash_balance: 0,
+      start_non_cash_balance: 0,
+      cash_inflows: 500,
+      cash_outflows: 0,
+      non_cash_inflows: 0,
+      non_cash_outflows: 0,
+      net_market_flows: 0,
+      cash_adjustments: 0,
+      non_cash_adjustments: 0,
+      currency: "USD"
+    )
+    @investment.balances.create!(
+      date: @test_period_start + 1.day,
+      balance: 500,  # Keep old field for now
+      cash_balance: 500,  # Keep old field for now
+      start_balance: 500,
+      start_cash_balance: 500,
+      start_non_cash_balance: 0,
+      cash_inflows: 0,
+      cash_outflows: 0,
+      non_cash_inflows: 0,
+      non_cash_outflows: 0,
+      net_market_flows: 0,
+      cash_adjustments: 0,
+      non_cash_adjustments: 0,
+      currency: "USD"
+    )
+    @investment.balances.create!(
+      date: @test_period_start + 2.days,
+      balance: 1900,  # Keep old field for now
+      cash_balance: 400,  # Keep old field for now
+      start_balance: 500,
+      start_cash_balance: 500,
+      start_non_cash_balance: 0,
+      cash_inflows: 0,
+      cash_outflows: 100,
+      non_cash_inflows: 1500,
+      non_cash_outflows: 0,
+      net_market_flows: 0,
+      cash_adjustments: 0,
+      non_cash_adjustments: 0,
+      currency: "USD"
+    )
+
+    # Day 1: Regular transaction
+    create_transaction(
+      account: @checking,
+      date: @test_period_start,
+      amount: -50,
+      name: "Grocery Store"
+    )
+
+    # Day 2: Transfer between accounts
+    @transfer = create_transfer(
+      from_account: @checking,
+      to_account: @savings,
+      amount: 200,
+      date: @test_period_start + 1.day
+    )
+
+    # Day 3: Trade in investment account
+    create_trade(
+      securities(:aapl),
+      account: @investment,
+      qty: 10,
+      date: @test_period_start + 2.days,
+      price: 150
+    )
+
+    # Day 3: Foreign currency transaction
+    create_transaction(
+      account: @investment,
+      date: @test_period_start + 2.days,
+      amount: -100,
+      currency: "EUR",
+      name: "International Wire"
+    )
+
+    # Create exchange rate for foreign currency
+    ExchangeRate.create!(
+      date: @test_period_start + 2.days,
+      from_currency: "EUR",
+      to_currency: "USD",
+      rate: 1.1
+    )
+
+    # Day 4: Valuation
+    create_valuation(
+      account: @investment,
+      date: @test_period_start + 3.days,
+      amount: 25
+    )
+  end
 end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -119,32 +119,32 @@ class AssistantTest < ActiveSupport::TestCase
   end
 
   private
-    def provider_function_request(id:, call_id:, function_name:, function_args:)
-      Provider::LlmConcept::ChatFunctionRequest.new(
+  def provider_function_request(id:, call_id:, function_name:, function_args:)
+    Provider::LlmConcept::ChatFunctionRequest.new(
+      id: id,
+      call_id: call_id,
+      function_name: function_name,
+      function_args: function_args
+    )
+  end
+
+  def provider_message(id:, text:)
+    Provider::LlmConcept::ChatMessage.new(id: id, output_text: text)
+  end
+
+  def provider_text_chunk(text)
+    Provider::LlmConcept::ChatStreamChunk.new(type: "output_text", data: text)
+  end
+
+  def provider_response_chunk(id:, model:, messages:, function_requests:)
+    Provider::LlmConcept::ChatStreamChunk.new(
+      type: "response",
+      data: Provider::LlmConcept::ChatResponse.new(
         id: id,
-        call_id: call_id,
-        function_name: function_name,
-        function_args: function_args
+        model: model,
+        messages: messages,
+        function_requests: function_requests
       )
-    end
-
-    def provider_message(id:, text:)
-      Provider::LlmConcept::ChatMessage.new(id: id, output_text: text)
-    end
-
-    def provider_text_chunk(text)
-      Provider::LlmConcept::ChatStreamChunk.new(type: "output_text", data: text)
-    end
-
-    def provider_response_chunk(id:, model:, messages:, function_requests:)
-      Provider::LlmConcept::ChatStreamChunk.new(
-        type: "response",
-        data: Provider::LlmConcept::ChatResponse.new(
-          id: id,
-          model: model,
-          messages: messages,
-          function_requests: function_requests
-        )
-      )
-    end
+    )
+  end
 end

--- a/test/models/balance/forward_calculator_test.rb
+++ b/test/models/balance/forward_calculator_test.rb
@@ -582,15 +582,15 @@ class Balance::ForwardCalculatorTest < ActiveSupport::TestCase
   end
 
   private
-    def assert_balances(calculated_data:, expected_balances:)
-      # Sort calculated data by date to ensure consistent ordering
-      sorted_data = calculated_data.sort_by(&:date)
+  def assert_balances(calculated_data:, expected_balances:)
+    # Sort calculated data by date to ensure consistent ordering
+    sorted_data = calculated_data.sort_by(&:date)
 
-      # Extract actual values as [date, { balance:, cash_balance: }]
-      actual_balances = sorted_data.map do |b|
-        [b.date, { balance: b.balance, cash_balance: b.cash_balance }]
-      end
-
-      assert_equal expected_balances, actual_balances
+    # Extract actual values as [date, { balance:, cash_balance: }]
+    actual_balances = sorted_data.map do |b|
+      [b.date, { balance: b.balance, cash_balance: b.cash_balance }]
     end
+
+    assert_equal expected_balances, actual_balances
+  end
 end

--- a/test/models/balance/materializer_test.rb
+++ b/test/models/balance/materializer_test.rb
@@ -136,24 +136,24 @@ class Balance::MaterializerTest < ActiveSupport::TestCase
 
   private
 
-    def assert_balance_fields_persisted(expected_balances)
-      expected_balances.each do |expected|
-        persisted = @account.balances.find_by(date: expected.date)
-        assert_not_nil persisted, "Balance for #{expected.date} should be persisted"
+  def assert_balance_fields_persisted(expected_balances)
+    expected_balances.each do |expected|
+      persisted = @account.balances.find_by(date: expected.date)
+      assert_not_nil persisted, "Balance for #{expected.date} should be persisted"
 
-        # Check all balance component fields
-        assert_equal expected.balance, persisted.balance
-        assert_equal expected.cash_balance, persisted.cash_balance
-        assert_equal expected.start_cash_balance, persisted.start_cash_balance
-        assert_equal expected.start_non_cash_balance, persisted.start_non_cash_balance
-        assert_equal expected.cash_inflows, persisted.cash_inflows
-        assert_equal expected.cash_outflows, persisted.cash_outflows
-        assert_equal expected.non_cash_inflows, persisted.non_cash_inflows
-        assert_equal expected.non_cash_outflows, persisted.non_cash_outflows
-        assert_equal expected.net_market_flows, persisted.net_market_flows
-        assert_equal expected.cash_adjustments, persisted.cash_adjustments
-        assert_equal expected.non_cash_adjustments, persisted.non_cash_adjustments
-        assert_equal expected.flows_factor, persisted.flows_factor
-      end
+      # Check all balance component fields
+      assert_equal expected.balance, persisted.balance
+      assert_equal expected.cash_balance, persisted.cash_balance
+      assert_equal expected.start_cash_balance, persisted.start_cash_balance
+      assert_equal expected.start_non_cash_balance, persisted.start_non_cash_balance
+      assert_equal expected.cash_inflows, persisted.cash_inflows
+      assert_equal expected.cash_outflows, persisted.cash_outflows
+      assert_equal expected.non_cash_inflows, persisted.non_cash_inflows
+      assert_equal expected.non_cash_outflows, persisted.non_cash_outflows
+      assert_equal expected.net_market_flows, persisted.net_market_flows
+      assert_equal expected.cash_adjustments, persisted.cash_adjustments
+      assert_equal expected.non_cash_adjustments, persisted.non_cash_adjustments
+      assert_equal expected.flows_factor, persisted.flows_factor
     end
+  end
 end

--- a/test/models/balance_sheet_test.rb
+++ b/test/models/balance_sheet_test.rb
@@ -76,8 +76,8 @@ class BalanceSheetTest < ActiveSupport::TestCase
   end
 
   private
-    def create_account(attributes = {})
-      account = @family.accounts.create! name: "Test", currency: "USD", **attributes
-      account
-    end
+  def create_account(attributes = {})
+    account = @family.accounts.create! name: "Test", currency: "USD", **attributes
+    account
+  end
 end

--- a/test/models/exchange_rate/importer_test.rb
+++ b/test/models/exchange_rate/importer_test.rb
@@ -141,8 +141,8 @@ class ExchangeRate::ImporterTest < ActiveSupport::TestCase
   end
 
   private
-    def get_provider_fetch_start_date(start_date)
-      # We fetch with a 5 day buffer to account for weekends and holidays
-      start_date - 5.days
-    end
+  def get_provider_fetch_start_date(start_date)
+    # We fetch with a 5 day buffer to account for weekends and holidays
+    start_date - 5.days
+  end
 end

--- a/test/models/family/auto_categorizer_test.rb
+++ b/test/models/family/auto_categorizer_test.rb
@@ -38,5 +38,5 @@ class Family::AutoCategorizerTest < ActiveSupport::TestCase
   end
 
   private
-    AutoCategorization = Provider::LlmConcept::AutoCategorization
+  AutoCategorization = Provider::LlmConcept::AutoCategorization
 end

--- a/test/models/family/auto_merchant_detector_test.rb
+++ b/test/models/family/auto_merchant_detector_test.rb
@@ -38,5 +38,5 @@ class Family::AutoMerchantDetectorTest < ActiveSupport::TestCase
   end
 
   private
-    AutoDetectedMerchant = Provider::LlmConcept::AutoDetectedMerchant
+  AutoDetectedMerchant = Provider::LlmConcept::AutoDetectedMerchant
 end

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -118,31 +118,31 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
   end
 
   private
-    def load_exchange_prices
-      rates = {
-        4.days.ago.to_date => 1.36,
-        3.days.ago.to_date => 1.37,
-        2.days.ago.to_date => 1.38,
-        1.day.ago.to_date  => 1.39,
-        Date.current => 1.40
-      }
+  def load_exchange_prices
+    rates = {
+      4.days.ago.to_date => 1.36,
+      3.days.ago.to_date => 1.37,
+      2.days.ago.to_date => 1.38,
+      1.day.ago.to_date  => 1.39,
+      Date.current => 1.40
+    }
 
-      rates.each do |date, rate|
-        # USD to CAD
-        ExchangeRate.create!(
-          from_currency: "USD",
-          to_currency: "CAD",
-          date: date,
-          rate: rate
-        )
+    rates.each do |date, rate|
+      # USD to CAD
+      ExchangeRate.create!(
+        from_currency: "USD",
+        to_currency: "CAD",
+        date: date,
+        rate: rate
+      )
 
-        # CAD to USD (inverse)
-        ExchangeRate.create!(
-          from_currency: "CAD",
-          to_currency: "USD",
-          date: date,
-          rate: (1.0 / rate).round(6)
-        )
-      end
+      # CAD to USD (inverse)
+      ExchangeRate.create!(
+        from_currency: "CAD",
+        to_currency: "USD",
+        date: date,
+        rate: (1.0 / rate).round(6)
+      )
     end
+  end
 end

--- a/test/models/holding/forward_calculator_test.rb
+++ b/test/models/holding/forward_calculator_test.rb
@@ -131,36 +131,36 @@ class Holding::ForwardCalculatorTest < ActiveSupport::TestCase
   end
 
   private
-    def assert_holdings(expected, calculated)
-      expected.each do |expected_entry|
-        calculated_entry = calculated.find { |c| c.security == expected_entry.security && c.date == expected_entry.date }
+  def assert_holdings(expected, calculated)
+    expected.each do |expected_entry|
+      calculated_entry = calculated.find { |c| c.security == expected_entry.security && c.date == expected_entry.date }
 
-        assert_equal expected_entry.qty, calculated_entry.qty, "Qty mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-        assert_equal expected_entry.price, calculated_entry.price, "Price mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-        assert_equal expected_entry.amount, calculated_entry.amount, "Amount mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-      end
+      assert_equal expected_entry.qty, calculated_entry.qty, "Qty mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
+      assert_equal expected_entry.price, calculated_entry.price, "Price mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
+      assert_equal expected_entry.amount, calculated_entry.amount, "Amount mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
     end
+  end
 
-    def load_prices
-      @voo = Security.create!(ticker: "VOO", name: "Vanguard S&P 500 ETF")
-      Security::Price.create!(security: @voo, date: 4.days.ago.to_date, price: 460)
-      Security::Price.create!(security: @voo, date: 3.days.ago.to_date, price: 470)
-      Security::Price.create!(security: @voo, date: 2.days.ago.to_date, price: 480)
-      Security::Price.create!(security: @voo, date: 1.day.ago.to_date, price: 490)
-      Security::Price.create!(security: @voo, date: Date.current, price: 500)
+  def load_prices
+    @voo = Security.create!(ticker: "VOO", name: "Vanguard S&P 500 ETF")
+    Security::Price.create!(security: @voo, date: 4.days.ago.to_date, price: 460)
+    Security::Price.create!(security: @voo, date: 3.days.ago.to_date, price: 470)
+    Security::Price.create!(security: @voo, date: 2.days.ago.to_date, price: 480)
+    Security::Price.create!(security: @voo, date: 1.day.ago.to_date, price: 490)
+    Security::Price.create!(security: @voo, date: Date.current, price: 500)
 
-      @wmt = Security.create!(ticker: "WMT", name: "Walmart Inc.")
-      Security::Price.create!(security: @wmt, date: 4.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 3.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 2.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 1.day.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: Date.current, price: 100)
+    @wmt = Security.create!(ticker: "WMT", name: "Walmart Inc.")
+    Security::Price.create!(security: @wmt, date: 4.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 3.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 2.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 1.day.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: Date.current, price: 100)
 
-      @amzn = Security.create!(ticker: "AMZN", name: "Amazon.com Inc.")
-      Security::Price.create!(security: @amzn, date: 4.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 3.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 2.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 1.day.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: Date.current, price: 200)
-    end
+    @amzn = Security.create!(ticker: "AMZN", name: "Amazon.com Inc.")
+    Security::Price.create!(security: @amzn, date: 4.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 3.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 2.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 1.day.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: Date.current, price: 200)
+  end
 end

--- a/test/models/holding/reverse_calculator_test.rb
+++ b/test/models/holding/reverse_calculator_test.rb
@@ -159,70 +159,70 @@ class Holding::ReverseCalculatorTest < ActiveSupport::TestCase
   end
 
   private
-    def assert_holdings(expected, calculated)
-      expected.each do |expected_entry|
-        calculated_entry = calculated.find { |c| c.security == expected_entry.security && c.date == expected_entry.date }
+  def assert_holdings(expected, calculated)
+    expected.each do |expected_entry|
+      calculated_entry = calculated.find { |c| c.security == expected_entry.security && c.date == expected_entry.date }
 
-        assert_equal expected_entry.qty, calculated_entry.qty, "Qty mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-        assert_equal expected_entry.price, calculated_entry.price, "Price mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-        assert_equal expected_entry.amount, calculated_entry.amount, "Amount mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
-      end
+      assert_equal expected_entry.qty, calculated_entry.qty, "Qty mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
+      assert_equal expected_entry.price, calculated_entry.price, "Price mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
+      assert_equal expected_entry.amount, calculated_entry.amount, "Amount mismatch for #{expected_entry.security.ticker} on #{expected_entry.date}"
     end
+  end
 
-    def load_prices
-      @voo = Security.create!(ticker: "VOO", name: "Vanguard S&P 500 ETF")
-      Security::Price.create!(security: @voo, date: 4.days.ago.to_date, price: 460)
-      Security::Price.create!(security: @voo, date: 3.days.ago.to_date, price: 470)
-      Security::Price.create!(security: @voo, date: 2.days.ago.to_date, price: 480)
-      Security::Price.create!(security: @voo, date: 1.day.ago.to_date, price: 490)
-      Security::Price.create!(security: @voo, date: Date.current, price: 500)
+  def load_prices
+    @voo = Security.create!(ticker: "VOO", name: "Vanguard S&P 500 ETF")
+    Security::Price.create!(security: @voo, date: 4.days.ago.to_date, price: 460)
+    Security::Price.create!(security: @voo, date: 3.days.ago.to_date, price: 470)
+    Security::Price.create!(security: @voo, date: 2.days.ago.to_date, price: 480)
+    Security::Price.create!(security: @voo, date: 1.day.ago.to_date, price: 490)
+    Security::Price.create!(security: @voo, date: Date.current, price: 500)
 
-      @wmt = Security.create!(ticker: "WMT", name: "Walmart Inc.")
-      Security::Price.create!(security: @wmt, date: 4.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 3.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 2.days.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: 1.day.ago.to_date, price: 100)
-      Security::Price.create!(security: @wmt, date: Date.current, price: 100)
+    @wmt = Security.create!(ticker: "WMT", name: "Walmart Inc.")
+    Security::Price.create!(security: @wmt, date: 4.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 3.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 2.days.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: 1.day.ago.to_date, price: 100)
+    Security::Price.create!(security: @wmt, date: Date.current, price: 100)
 
-      @amzn = Security.create!(ticker: "AMZN", name: "Amazon.com Inc.")
-      Security::Price.create!(security: @amzn, date: 4.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 3.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 2.days.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: 1.day.ago.to_date, price: 200)
-      Security::Price.create!(security: @amzn, date: Date.current, price: 200)
-    end
+    @amzn = Security.create!(ticker: "AMZN", name: "Amazon.com Inc.")
+    Security::Price.create!(security: @amzn, date: 4.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 3.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 2.days.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: 1.day.ago.to_date, price: 200)
+    Security::Price.create!(security: @amzn, date: Date.current, price: 200)
+  end
 
-    # Portfolio holdings:
-    # +--------+-----+--------+---------+
-    # | Ticker | Qty | Price  | Amount  |
-    # +--------+-----+--------+---------+
-    # | VOO    |  10 | $500   | $5,000  |
-    # | WMT    | 100 | $100   | $10,000 |
-    # +--------+-----+--------+---------+
-    # Brokerage Cash: $5,000
-    # Holdings Value: $15,000
-    # Total Balance: $20,000
-    def load_today_portfolio
-      @account.update!(cash_balance: 5000)
+  # Portfolio holdings:
+  # +--------+-----+--------+---------+
+  # | Ticker | Qty | Price  | Amount  |
+  # +--------+-----+--------+---------+
+  # | VOO    |  10 | $500   | $5,000  |
+  # | WMT    | 100 | $100   | $10,000 |
+  # +--------+-----+--------+---------+
+  # Brokerage Cash: $5,000
+  # Holdings Value: $15,000
+  # Total Balance: $20,000
+  def load_today_portfolio
+    @account.update!(cash_balance: 5000)
 
-      load_prices
+    load_prices
 
-      @account.holdings.create!(
-        date: Date.current,
-        price: 500,
-        qty: 10,
-        amount: 5000,
-        currency: "USD",
-        security: @voo
-      )
+    @account.holdings.create!(
+      date: Date.current,
+      price: 500,
+      qty: 10,
+      amount: 5000,
+      currency: "USD",
+      security: @voo
+    )
 
-      @account.holdings.create!(
-        date: Date.current,
-        price: 100,
-        qty: 100,
-        amount: 10000,
-        currency: "USD",
-        security: @wmt
-      )
-    end
+    @account.holdings.create!(
+      date: Date.current,
+      price: 100,
+      qty: 100,
+      amount: 10000,
+      currency: "USD",
+      security: @wmt
+    )
+  end
 end

--- a/test/models/holding_test.rb
+++ b/test/models/holding_test.rb
@@ -56,35 +56,35 @@ class HoldingTest < ActiveSupport::TestCase
 
   private
 
-    def load_holdings
-      security1 = create_security("AMZN", prices: [
-        { date: 1.day.ago.to_date, price: 212.00 },
-        { date: Date.current, price: 216.00 }
-      ])
+  def load_holdings
+    security1 = create_security("AMZN", prices: [
+      { date: 1.day.ago.to_date, price: 212.00 },
+      { date: Date.current, price: 216.00 }
+    ])
 
-      security2 = create_security("NVDA", prices: [
-        { date: 1.day.ago.to_date, price: 128.00 },
-        { date: Date.current, price: 124.00 }
-      ])
+    security2 = create_security("NVDA", prices: [
+      { date: 1.day.ago.to_date, price: 128.00 },
+      { date: Date.current, price: 124.00 }
+    ])
 
-      create_holding(security1, 1.day.ago.to_date, 10)
-      amzn = create_holding(security1, Date.current, 15)
+    create_holding(security1, 1.day.ago.to_date, 10)
+    amzn = create_holding(security1, Date.current, 15)
 
-      create_holding(security2, 1.day.ago.to_date, 5)
-      nvda = create_holding(security2, Date.current, 30)
+    create_holding(security2, 1.day.ago.to_date, 5)
+    nvda = create_holding(security2, Date.current, 30)
 
-      [amzn, nvda]
-    end
+    [amzn, nvda]
+  end
 
-    def create_holding(security, date, qty)
-      price = Security::Price.find_by(date: date, security: security).price
+  def create_holding(security, date, qty)
+    price = Security::Price.find_by(date: date, security: security).price
 
-      @account.holdings.create! \
-        date: date,
-        security: security,
-        qty: qty,
-        price: price,
-        amount: qty * price,
-        currency: "USD"
-    end
+    @account.holdings.create! \
+      date: date,
+      security: security,
+      qty: qty,
+      price: price,
+      amount: qty * price,
+      currency: "USD"
+  end
 end

--- a/test/models/plaid_account/processor_test.rb
+++ b/test/models/plaid_account/processor_test.rb
@@ -224,30 +224,30 @@ class PlaidAccount::ProcessorTest < ActiveSupport::TestCase
   end
 
   private
-    def expect_investment_product_processor_calls
-      PlaidAccount::Investments::TransactionsProcessor.any_instance.expects(:process).once
-      PlaidAccount::Investments::HoldingsProcessor.any_instance.expects(:process).once
-    end
+  def expect_investment_product_processor_calls
+    PlaidAccount::Investments::TransactionsProcessor.any_instance.expects(:process).once
+    PlaidAccount::Investments::HoldingsProcessor.any_instance.expects(:process).once
+  end
 
-    def expect_depository_product_processor_calls
-      PlaidAccount::Transactions::Processor.any_instance.expects(:process).once
-    end
+  def expect_depository_product_processor_calls
+    PlaidAccount::Transactions::Processor.any_instance.expects(:process).once
+  end
 
-    def expect_no_investment_balance_calculator_calls
-      PlaidAccount::Investments::BalanceCalculator.any_instance.expects(:balance).never
-      PlaidAccount::Investments::BalanceCalculator.any_instance.expects(:cash_balance).never
-    end
+  def expect_no_investment_balance_calculator_calls
+    PlaidAccount::Investments::BalanceCalculator.any_instance.expects(:balance).never
+    PlaidAccount::Investments::BalanceCalculator.any_instance.expects(:cash_balance).never
+  end
 
-    def expect_no_liability_processor_calls
-      PlaidAccount::Liabilities::CreditProcessor.any_instance.expects(:process).never
-      PlaidAccount::Liabilities::MortgageProcessor.any_instance.expects(:process).never
-      PlaidAccount::Liabilities::StudentLoanProcessor.any_instance.expects(:process).never
-    end
+  def expect_no_liability_processor_calls
+    PlaidAccount::Liabilities::CreditProcessor.any_instance.expects(:process).never
+    PlaidAccount::Liabilities::MortgageProcessor.any_instance.expects(:process).never
+    PlaidAccount::Liabilities::StudentLoanProcessor.any_instance.expects(:process).never
+  end
 
-    def expect_default_subprocessor_calls
-      expect_depository_product_processor_calls
-      expect_investment_product_processor_calls
-      expect_no_investment_balance_calculator_calls
-      expect_no_liability_processor_calls
-    end
+  def expect_default_subprocessor_calls
+    expect_depository_product_processor_calls
+    expect_investment_product_processor_calls
+    expect_no_investment_balance_calculator_calls
+    expect_no_liability_processor_calls
+  end
 end

--- a/test/models/provider/plaid_test.rb
+++ b/test/models/provider/plaid_test.rb
@@ -70,11 +70,11 @@ class Provider::PlaidTest < ActiveSupport::TestCase
   end
 
   private
-    def get_access_token
-      VCR.use_cassette("plaid/access_token") do
-        public_token = @plaid.create_public_token
-        exchange_response = @plaid.exchange_public_token(public_token)
-        exchange_response.access_token
-      end
+  def get_access_token
+    VCR.use_cassette("plaid/access_token") do
+      public_token = @plaid.create_public_token
+      exchange_response = @plaid.exchange_public_token(public_token)
+      exchange_response.access_token
     end
+  end
 end

--- a/test/models/security/price/importer_test.rb
+++ b/test/models/security/price/importer_test.rb
@@ -137,7 +137,7 @@ class Security::Price::ImporterTest < ActiveSupport::TestCase
   end
 
   private
-    def get_provider_fetch_start_date(start_date)
-      start_date - 5.days
-    end
+  def get_provider_fetch_start_date(start_date)
+    start_date - 5.days
+  end
 end

--- a/test/models/security/price_test.rb
+++ b/test/models/security/price_test.rb
@@ -50,15 +50,15 @@ class Security::PriceTest < ActiveSupport::TestCase
   end
 
   private
-    def expect_provider_price(security:, price:, date:)
-      @provider.expects(:fetch_security_price)
-               .with(symbol: security.ticker, exchange_operating_mic: security.exchange_operating_mic, date: date)
-               .returns(provider_success_response(price))
-    end
+  def expect_provider_price(security:, price:, date:)
+    @provider.expects(:fetch_security_price)
+             .with(symbol: security.ticker, exchange_operating_mic: security.exchange_operating_mic, date: date)
+             .returns(provider_success_response(price))
+  end
 
-    def expect_provider_prices(security:, prices:, start_date:, end_date:)
-      @provider.expects(:fetch_security_prices)
-               .with(security, start_date: start_date, end_date: end_date)
-               .returns(provider_success_response(prices))
-    end
+  def expect_provider_prices(security:, prices:, start_date:, end_date:)
+    @provider.expects(:fetch_security_prices)
+             .with(security, start_date: start_date, end_date: end_date)
+             .returns(provider_success_response(prices))
+  end
 end

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -113,8 +113,8 @@ class TransactionImportTest < ActiveSupport::TestCase
       before importing.
 
       #Data operacji;#Opis operacji;#Rachunek;#Kategoria;#Kwota;
-      2025-12-28;"Żabka  ZAKUP PRZY UŻYCIU KARTY W KRAJU transakcja nierozliczona";"mKonto Intensive 6311 ... 0016";"Żywność i chemia domowa";-7,57 PLN;;
-      2025-12-27;"Trattoria Numero Uno  ZAKUP PRZY UŻYCIU KARTY W KRAJU transakcja nierozliczona";"mKonto Intensive 6311 ... 0016";"Jedzenie poza domem";-61,00 PLN;;
+      2025-12-28;"Żabka  ZAKUP PRZY UŻYCIU KARTY W KRAJU transakcja nierozliczona";"mKonto Intensive 6311 ... 0016";"Żywność i chemia domowa";-7,57 PLN;
+      2025-12-27;"Trattoria Numero Uno  ZAKUP PRZY UŻYCIU KARTY W KRAJU transakcja nierozliczona";"mKonto Intensive 6311 ... 0016";"Jedzenie poza domem";-61,00 PLN;
     CSV
 
     @import.update!(
@@ -137,6 +137,6 @@ class TransactionImportTest < ActiveSupport::TestCase
       @import.publish
     end
 
-    assert_equal [-100, -200], @import.entries.map(&:amount)
+    assert_equal [7.57, 61.00], @import.entries.map(&:amount)
   end
 end

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -97,50 +97,50 @@ class AccountsTest < ApplicationSystemTestCase
 
   private
 
-    def open_new_account_modal
-      within "[data-controller='DS--tabs']" do
-        click_button "All"
-        click_link "New account"
-      end
+  def open_new_account_modal
+    within "[data-controller='DS--tabs']" do
+      click_button "All"
+      click_link "New account"
     end
+  end
 
-    def assert_account_created(accountable_type, &block)
-      click_link Accountable.from_type(accountable_type).display_name.singularize
-      click_link "Enter account balance" if accountable_type.in?(%w[Depository Investment Crypto Loan CreditCard])
+  def assert_account_created(accountable_type, &block)
+    click_link Accountable.from_type(accountable_type).display_name.singularize
+    click_link "Enter account balance" if accountable_type.in?(%w[Depository Investment Crypto Loan CreditCard])
 
-      account_name = "[system test] #{accountable_type} Account"
+    account_name = "[system test] #{accountable_type} Account"
 
-      fill_in "Account name*", with: account_name
-      fill_in "account[balance]", with: 100.99
+    fill_in "Account name*", with: account_name
+    fill_in "account[balance]", with: 100.99
 
-      yield if block_given?
+    yield if block_given?
 
-      click_button "Create Account"
+    click_button "Create Account"
 
-      within_testid("account-sidebar-tabs") do
-        click_on "All"
-        find("details", text: Accountable.from_type(accountable_type).display_name).click
-        assert_text account_name
-      end
-
-      visit accounts_url
+    within_testid("account-sidebar-tabs") do
+      click_on "All"
+      find("details", text: Accountable.from_type(accountable_type).display_name).click
       assert_text account_name
-
-      created_account = Account.order(:created_at).last
-
-      visit account_url(created_account)
-
-      within_testid("account-menu") do
-        find("button").click
-        click_on "Edit"
-      end
-
-      fill_in "Account name", with: "Updated account name"
-      click_button "Update Account"
-      assert_selector "h2", text: "Updated account name"
     end
 
-    def humanized_accountable(accountable_type)
-      Accountable.from_type(accountable_type).display_name.singularize
+    visit accounts_url
+    assert_text account_name
+
+    created_account = Account.order(:created_at).last
+
+    visit account_url(created_account)
+
+    within_testid("account-menu") do
+      find("button").click
+      click_on "Edit"
     end
+
+    fill_in "Account name", with: "Updated account name"
+    click_button "Update Account"
+    assert_selector "h2", text: "Updated account name"
+  end
+
+  def humanized_accountable(accountable_type)
+    Accountable.from_type(accountable_type).display_name.singularize
+  end
 end

--- a/test/system/onboardings_test.rb
+++ b/test/system/onboardings_test.rb
@@ -181,15 +181,15 @@ class OnboardingsTest < ApplicationSystemTestCase
 
   private
 
-    def sign_in(user)
-      visit new_session_path
-      within "form" do
-        fill_in "Email", with: user.email
-        fill_in "Password", with: user_password_test
-        click_on "Log in"
-      end
-
-      # Wait for successful login
-      assert_current_path root_path
+  def sign_in(user)
+    visit new_session_path
+    within "form" do
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user_password_test
+      click_on "Log in"
     end
+
+    # Wait for successful login
+    assert_current_path root_path
+  end
 end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -55,10 +55,10 @@ class SettingsTest < ApplicationSystemTestCase
 
   private
 
-    def open_settings_from_sidebar
-      within "div[data-testid=user-menu]" do
-        find("button").click
-      end
-      click_link "Settings"
+  def open_settings_from_sidebar
+    within "div[data-testid=user-menu]" do
+      find("button").click
     end
+    click_link "Settings"
+  end
 end

--- a/test/system/trades_test.rb
+++ b/test/system/trades_test.rb
@@ -61,19 +61,19 @@ class TradesTest < ApplicationSystemTestCase
   end
 
   private
-    def open_new_trade_modal
-      click_on "New transaction"
-    end
+  def open_new_trade_modal
+    click_on "New transaction"
+  end
 
-    def within_trades(&block)
-      within "#" + dom_id(@account, "entries"), &block
-    end
+  def within_trades(&block)
+    within "#" + dom_id(@account, "entries"), &block
+  end
 
-    def visit_trades
-      visit account_path(@account, tab: "activity")
-    end
+  def visit_trades
+    visit account_path(@account, tab: "activity")
+  end
 
-    def visit_account_portfolio
-      visit account_path(@account, tab: "holdings")
-    end
+  def visit_account_portfolio
+    visit account_path(@account, tab: "holdings")
+  end
 end

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -215,40 +215,40 @@ class TransactionsTest < ApplicationSystemTestCase
 
   private
 
-    def create_transaction(name, date, amount, category: nil, merchant: nil, tags: [], account: nil)
-      account ||= accounts(:depository)
+  def create_transaction(name, date, amount, category: nil, merchant: nil, tags: [], account: nil)
+    account ||= accounts(:depository)
 
-      account.entries.create! \
-        name: name,
-        date: date,
-        amount: amount,
-        currency: "USD",
-        entryable: Transaction.new(category: category, merchant: merchant, tags: tags)
-    end
+    account.entries.create! \
+      name: name,
+      date: date,
+      amount: amount,
+      currency: "USD",
+      entryable: Transaction.new(category: category, merchant: merchant, tags: tags)
+  end
 
-    def number_of_transactions_on_page
-      [@user.family.entries.count, @page_size].min
-    end
+  def number_of_transactions_on_page
+    [@user.family.entries.count, @page_size].min
+  end
 
-    def all_transactions_checkbox
-      find("#selection_entry")
-    end
+  def all_transactions_checkbox
+    find("#selection_entry")
+  end
 
-    def date_transactions_checkbox(date)
-      find("#selection_entry_#{date}")
-    end
+  def date_transactions_checkbox(date)
+    find("#selection_entry_#{date}")
+  end
 
-    def transaction_checkbox(transaction)
-      find("#" + dom_id(transaction, "selection"))
-    end
+  def transaction_checkbox(transaction)
+    find("#" + dom_id(transaction, "selection"))
+  end
 
-    def assert_selection_count(count)
-      if count == 0
-        assert_no_selector("#entry-selection-bar")
-      else
-        within "#entry-selection-bar" do
-          assert_text "#{count} transaction#{count == 1 ? "" : "s"} selected"
-        end
+  def assert_selection_count(count)
+    if count == 0
+      assert_no_selector("#entry-selection-bar")
+    else
+      within "#entry-selection-bar" do
+        assert_text "#{count} transaction#{count == 1 ? "" : "s"} selected"
       end
     end
+  end
 end


### PR DESCRIPTION
Improvements for parsing raw csv string for mBank transactions statements:

* reduntant rows at the beginning of the statement are properly removed
* amount is converted ("-7,57 PLN" to "-7.57")

Misc changes:
* default extensions added to the devcontainer.json, so they don't have to be reinstalled on every rebuild
* rubocop's Layout/IndentationConsistency EnforcedStyle changed to normal (2 spaces insted of 4 for internal methods)

